### PR TITLE
feat(acs): add dedicated DSC/DEC for UEFI build

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For more information, see [arm RME System ACS Validation Methodology document](D
    - platform/pal_baremetal/FVP/include/platform_override_fvp.h -> For Bare-metal platform,
    - platform/pal_uefi/include/platform_overrride.h -> For UEFI platform.
 - Any mainstream Linux based OS distribution running on a x86 or aarch64 machine.
-- git clone --branch edk2-stable202208 --depth 1 https://github.com/tianocore/edk2
+- git clone --branch edk2-stable202505 --depth 1 https://github.com/tianocore/edk2
 - git clone https://github.com/tianocore/edk2-libc [ Checkout SHA: 61687168fe02ac4d933a36c9145fdd242ac424d1]
 - Install GCC 13.2 or later toolchain for Linux from [here](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads).
 - Install the build prerequisite packages to build EDK2.
@@ -71,10 +71,6 @@ To start the ACS build, perform the following steps:
 2.  git clone https://github.com/tianocore/edk2-libc
 3.  git submodule update --init --recursive
 4.  git clone https://github.com/ARM-software/rme-sysarch-acs ShellPkg/Application/rme-acs
-5.  Add the following to the [LibraryClasses.common] section in ShellPkg/ShellPkg.dsc
-   - Add  RmeValLib|ShellPkg/Application/rme-acs/val/RmeValLib.inf
-   - Add  RmePalLib|ShellPkg/Application/rme-acs/platform/pal_uefi/RmePalLib.inf
-   - Add ShellPkg/Application/rme-acs/uefi_app/RmeAcs.inf in the [components] section of ShellPkg/ShellPkg.dsc <br>
 
 ### Linux build environment
 If the build environment is Linux, perform the following steps:
@@ -87,7 +83,7 @@ If the build environment is Linux, perform the following steps:
 
 ### Build output
 
-The EFI executable file is generated at <edk2_path>/Build/Shell/DEBUG_GCC49/AARCH64/Rme.efi
+The EFI executable file is generated at <edk2_path>/Build/RmeAcs/DEBUG_GCC49/AARCH64/Rme.efi
 
 
 ## Test suite execution

--- a/tools/scripts/acsbuild.sh
+++ b/tools/scripts/acsbuild.sh
@@ -1,5 +1,5 @@
 ## @file
-#  Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+#  Copyright (c) 2025-2026, Arm Limited or its affiliates. All rights reserved.
 #  SPDX-License-Identifier : Apache-2.0
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,13 +22,14 @@ then
     return 0
 fi
 
+DSC_PATH=${RME_ACS_DSC:-ShellPkg/Application/rme-acs/uefi_app/RmeAcs.dsc}
+
 if [ "$1" == "ENABLE_OOB" ]; then
-    build -a AARCH64 -t GCC49 -p ShellPkg/ShellPkg.dsc \
+    build -a AARCH64 -t GCC49 -p ${DSC_PATH} \
             -m ShellPkg/Application/rme-acs/baremetal_app/RmeAcs.inf -D ENABLE_OOB
     return 0;
 fi
 
-    build -a AARCH64 -t GCC49 -p ShellPkg/ShellPkg.dsc \
+    build -a AARCH64 -t GCC49 -p ${DSC_PATH} -n 32 \
         -m ShellPkg/Application/rme-acs/uefi_app/RmeAcs.inf
-
 

--- a/uefi_app/RmeAcs.dec
+++ b/uefi_app/RmeAcs.dec
@@ -1,0 +1,16 @@
+## @file
+#  Package description for the RME ACS external integrations.
+#
+#  Copyright (c) 2026, Arm Limited.
+#  SPDX-License-Identifier: Apache-2.0
+#
+##
+
+[Defines]
+  DEC_SPECIFICATION              = 0x00010005
+  PACKAGE_NAME                   = RmeAcs
+  PACKAGE_GUID                   = 1E4A4AAC-0862-4789-A2C1-6272F63413E0
+  PACKAGE_VERSION                = 0.1
+
+[Includes]
+  ../val/include

--- a/uefi_app/RmeAcs.dsc
+++ b/uefi_app/RmeAcs.dsc
@@ -1,0 +1,70 @@
+## @file
+#  Platform description for the RME Architecture Compliance Suite UEFI application.
+#
+#  Copyright (c) 2026, Arm Limited.
+#  SPDX-License-Identifier: Apache-2.0
+#
+##
+
+[Defines]
+  PLATFORM_NAME                  = RmeAcs
+  PLATFORM_GUID                  = 2B2323C6-21C0-4D4C-A8A6-9E541F4562F3
+  PLATFORM_VERSION               = 0.1
+  DSC_SPECIFICATION              = 0x00010006
+  OUTPUT_DIRECTORY               = Build/RmeAcs
+  SUPPORTED_ARCHITECTURES        = AARCH64
+  BUILD_TARGETS                  = DEBUG|RELEASE
+  SKUID_IDENTIFIER               = DEFAULT
+
+!include MdePkg/MdeLibs.dsc.inc
+
+[Packages]
+  ArmPkg/ArmPkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  ShellPkg/ShellPkg.dec
+  ShellPkg/Application/rme-acs/uefi_app/RmeAcs.dec
+
+[LibraryClasses.common]
+  UefiApplicationEntryPoint|MdePkg/Library/UefiApplicationEntryPoint/UefiApplicationEntryPoint.inf
+  UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
+  DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
+  UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
+  UefiRuntimeServicesTableLib|MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
+!if $(TARGET) == RELEASE
+  DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+!else
+  DebugLib|MdePkg/Library/UefiDebugLibConOut/UefiDebugLibConOut.inf
+!endif
+  DebugPrintErrorLevelLib|MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf
+  PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+  MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
+  UefiLib|MdePkg/Library/UefiLib/UefiLib.inf
+  BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
+  CompilerIntrinsicsLib|MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+  BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
+  SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
+  PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
+  IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
+  SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
+  ShellLib|ShellPkg/Library/UefiShellLib/UefiShellLib.inf
+  ShellCEntryLib|ShellPkg/Library/UefiShellCEntryLib/UefiShellCEntryLib.inf
+  DxeServicesTableLib|MdePkg/Library/DxeServicesTableLib/DxeServicesTableLib.inf
+  DxeServicesLib|MdePkg/Library/DxeServicesLib/DxeServicesLib.inf
+  ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
+  TimerLib|MdePkg/Library/BaseTimerLibNullTemplate/BaseTimerLibNullTemplate.inf
+  FileHandleLib|MdePkg/Library/UefiFileHandleLib/UefiFileHandleLib.inf
+  UefiHiiServicesLib|MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.inf
+  HiiLib|MdeModulePkg/Library/UefiHiiLib/UefiHiiLib.inf
+  SortLib|MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
+  RmeValLib|ShellPkg/Application/rme-acs/val/RmeValLib.inf
+  RmePalLib|ShellPkg/Application/rme-acs/platform/pal_uefi/RmePalLib.inf
+
+[PcdsFixedAtBuild]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0xFF
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x80000000
+  gEfiMdePkgTokenSpaceGuid.PcdUefiLibMaxPrintBufferSize|16000
+
+[Components]
+  ShellPkg/Application/rme-acs/uefi_app/RmeAcs.inf


### PR DESCRIPTION
- Add RmeAcs.dsc and RmeAcs.dec so the ACS package no longer depends on ShellPkg.dsc of edk2.
- Update acsbuild.sh to use the new ACS DSC file for the build.