### PR TITLE
rme-acs: fix in-tree Coverity defects

### DIFF
--- a/platform/pal_baremetal/src/pal_pcie_enumeration.c
+++ b/platform/pal_baremetal/src/pal_pcie_enumeration.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2022-2023, 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2022-2023, 2025-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -825,23 +825,23 @@ pal_pcie_get_bdf_wrapper(uint32_t class_code, uint32_t start_bdf)
 void *
 pal_pci_bdf_to_dev(uint32_t bdf)
 {
+  static uint32_t device_id;
 
   uint32_t seg;
   uint32_t bus;
   uint32_t dev;
   uint32_t func;
-  uint32_t vendor_id, *device_id;
+  uint32_t cfg_data;
 
   seg  = PCIE_EXTRACT_BDF_SEG(bdf);
   bus  = PCIE_EXTRACT_BDF_BUS(bdf);
   dev  = PCIE_EXTRACT_BDF_DEV(bdf);
   func = PCIE_EXTRACT_BDF_FUNC(bdf);
 
-  pal_pci_cfg_read(seg, bus, dev, func, 0, &vendor_id);
-  vendor_id = vendor_id >> DEVICE_ID_OFFSET;
-  device_id = &vendor_id;
+  pal_pci_cfg_read(seg, bus, dev, func, 0, &cfg_data);
+  device_id = cfg_data >> DEVICE_ID_OFFSET;
 
-  return (void *)device_id;
+  return (void *)&device_id;
 
 }
 

--- a/test_pool/da/da_rmsd_write_detect_property.c
+++ b/test_pool/da/da_rmsd_write_detect_property.c
@@ -51,6 +51,7 @@ payload(void)
   uint32_t status;
   uint32_t table_entries;
   uint32_t rp_bdf, ep_index, ep_bdf, index;
+  uint32_t ep_found;
   pcie_cfgreg_bitfield_entry *bf_entry;
   uint32_t ep_locked = 0;
 
@@ -97,6 +98,7 @@ payload(void)
       }
 
       ep_index = 0;
+      ep_found = 0;
       while (ep_index < bdf_tbl_ptr->num_entries)
       {
           ep_bdf = bdf_tbl_ptr->device[ep_index++].bdf;
@@ -106,7 +108,16 @@ payload(void)
 
           val_pcie_get_rootport(ep_bdf, &rp_bdf);
           if (bdf == rp_bdf)
+          {
+              ep_found = 1;
               break;
+          }
+      }
+
+      if (!ep_found)
+      {
+          val_print(ACS_PRINT_WARN, " No endpoint found for RP BDF: 0x%x", bdf);
+          continue;
       }
 
       test_skip = 0;

--- a/test_pool/legacy_system/legacy_tz_en_drives_root_to_secure.c
+++ b/test_pool/legacy_system/legacy_tz_en_drives_root_to_secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,10 +41,10 @@ void
 payload()
 {
 
-  uint64_t rd_data;
+  uint64_t rd_data = 0u;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
-  uint32_t status_fail_cnt, attr;
-  uint64_t VA, PA, size, num_reg;
+  uint32_t status_fail_cnt = 0u, attr;
+  uint64_t VA = 0u, PA = 0u, size, num_reg;
   ROOT_REGSTR_TABLE *root_registers_cfg;
 
   size = val_get_min_tg();
@@ -54,11 +54,11 @@ payload()
   num_reg = root_registers_cfg->num_reg;
   attr = LOWER_ATTRS(PGT_ENTRY_ACCESS | SHAREABLE_ATTR(NON_SHAREABLE) | PGT_ENTRY_AP_RW);
   for (uint64_t reg_cnt = 0; reg_cnt < num_reg; ++reg_cnt) {
+    VA = val_get_free_va(size);
+    PA = root_registers_cfg->rt_reg_info[reg_cnt].rt_reg_base_addr;
 
     val_print(ACS_PRINT_TEST, " Checking for the region: 0x%llx", PA);
 
-    VA = val_get_free_va(size);
-    PA = root_registers_cfg->rt_reg_info[reg_cnt].rt_reg_base_addr;
     /* Use the register addresses as PAs to map them with secure access PAS */
     if (val_add_mmu_entry_el3(VA, PA, (attr | LOWER_ATTRS(PAS_ATTR(SECURE_PAS)))))
     {
@@ -118,5 +118,4 @@ legacy_tz_en_drives_root_to_secure_entry(uint32_t num_pe)
 
   return  status;
 }
-
 

--- a/test_pool/rme/rme_pcie_devices_support_gpc.c
+++ b/test_pool/rme/rme_pcie_devices_support_gpc.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2024, 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2024, 2025-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -166,22 +166,29 @@ payload (void)
 {
 
     uint32_t pe_index;
-    uint32_t instance;
-    uint32_t e_bdf, num_smmu;
+    uint32_t instance = 0;
+    uint32_t e_bdf = 0, num_smmu;
     void *dram_buf1_virt;
     void *dram_buf1_phys;
-    uint32_t cap_base;
+    uint32_t cap_base = 0;
     uint32_t reg_value = 0;
     uint32_t device_id, its_id;
     uint32_t page_size = val_memory_page_size();
-    uint64_t ttbr;
     uint32_t size;
+    uint32_t smmu_mapped = 0;
+    uint32_t exerciser_ready = 0;
     smmu_master_attributes_t master;
     memory_region_descriptor_t mem_desc_array[2], *mem_desc;
-    pgt_descriptor_t pgt_desc;
+    pgt_descriptor_t cpu_pgt_desc;
+    pgt_descriptor_t smmu_pgt_desc;
+    uint64_t ttbr = 0;
 
     dram_buf1_virt = NULL;
     dram_buf1_phys = NULL;
+    val_memory_set(&master, sizeof(master), 0);
+    master.smmu_index = ACS_INVALID_INDEX;
+    val_memory_set(&cpu_pgt_desc, sizeof(cpu_pgt_desc), 0);
+    val_memory_set(&smmu_pgt_desc, sizeof(smmu_pgt_desc), 0);
 
     test_data_blk_size = page_size * TEST_DATA_NUM_PAGES;
     pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -192,7 +199,7 @@ payload (void)
 
     /* Get translation attributes via TCR and translation table base via TTBR */
     if (val_pe_reg_read_tcr(0 /*for TTBR0*/,
-                            &pgt_desc.tcr)) {
+                            &cpu_pgt_desc.tcr)) {
       val_print(ACS_PRINT_ERR, " TCR read failure", 0);
       goto test_fail;
     }
@@ -204,7 +211,6 @@ payload (void)
     }
 
     /* Initialize DMA master and memory descriptors */
-    val_memory_set(&master, sizeof(master), 0);
     val_memory_set(mem_desc_array, sizeof(mem_desc_array), 0);
     mem_desc = &mem_desc_array[0];
 
@@ -214,7 +220,9 @@ payload (void)
 
     instance = 0;
     /* Initialise the exerciser */
-    val_exerciser_init(instance);
+    if (val_exerciser_init(instance))
+        goto test_fail;
+    exerciser_ready = 1;
 
     /* Get the exerciser BDF */
     e_bdf = val_exerciser_get_bdf(instance);
@@ -249,18 +257,18 @@ payload (void)
     reg_value |= ATS_CACHING_EN;
     val_pcie_write_cfg(e_bdf, cap_base + ATS_CTRL, reg_value);
 
-    pgt_desc.pgt_base = (ttbr & AARCH64_TTBR_ADDR_MASK);
-    pgt_desc.mair = val_pe_reg_read(MAIR_ELx);
-    pgt_desc.stage = PGT_STAGE1;
+    cpu_pgt_desc.pgt_base = (ttbr & AARCH64_TTBR_ADDR_MASK);
+    cpu_pgt_desc.mair = val_pe_reg_read(MAIR_ELx);
+    cpu_pgt_desc.stage = PGT_STAGE1;
 
-    pgt_desc.ias = 48;
-    pgt_desc.oas = 48;
+    cpu_pgt_desc.ias = 48;
+    cpu_pgt_desc.oas = 48;
     mem_desc->virtual_address = (uint64_t)dram_buf1_virt;
     mem_desc->physical_address = (uint64_t)dram_buf1_phys;
     mem_desc->length = test_data_blk_size * NUM_PAS;
     mem_desc->attributes |= (PGT_STAGE1_AP_RW);
 
-  if (val_pgt_create(mem_desc, &pgt_desc)) {
+  if (val_pgt_create(mem_desc, &cpu_pgt_desc)) {
         val_print(ACS_PRINT_ERR,
                       " Unable to create page table with given attributes", 0);
             goto test_fail;
@@ -269,7 +277,7 @@ payload (void)
     /* Get memory attributes of the test buffer, we'll use the same attibutes to create
      * our own page table later.
      */
-    if (val_pgt_get_attributes(pgt_desc, (uint64_t)dram_buf1_virt, &mem_desc->attributes)) {
+    if (val_pgt_get_attributes(cpu_pgt_desc, (uint64_t)dram_buf1_virt, &mem_desc->attributes)) {
         val_print(ACS_PRINT_ERR, " Unable to get memory attributes of the test buffer", 0);
         goto test_fail;
     }
@@ -319,24 +327,24 @@ payload (void)
       }
 
       /* Need to know input and output address sizes before creating page table */
-      pgt_desc.ias = val_smmu_get_info(SMMU_IN_ADDR_SIZE, master.smmu_index);
-      if ((pgt_desc.ias) == 0) {
+      smmu_pgt_desc = cpu_pgt_desc;
+      smmu_pgt_desc.ias = val_smmu_get_info(SMMU_IN_ADDR_SIZE, master.smmu_index);
+      if ((smmu_pgt_desc.ias) == 0) {
             val_print(ACS_PRINT_ERR,
                           " Input address size of SMMU %d is 0", master.smmu_index);
             goto test_fail;
       }
 
-      pgt_desc.oas = val_smmu_get_info(SMMU_OUT_ADDR_SIZE, master.smmu_index);
-      if ((pgt_desc.oas) == 0) {
+      smmu_pgt_desc.oas = val_smmu_get_info(SMMU_OUT_ADDR_SIZE, master.smmu_index);
+      if ((smmu_pgt_desc.oas) == 0) {
             val_print(ACS_PRINT_ERR,
                           " Output address size of SMMU %d is 0", master.smmu_index);
             goto test_fail;
       }
 
-      /* set pgt_desc.pgt_base to NULL to create new translation table, val_pgt_create
-         will update pgt_desc.pgt_base to point to created translation table */
-      pgt_desc.pgt_base = (uint64_t) NULL;
-      if (val_pgt_create(mem_desc, &pgt_desc)) {
+      /* set pgt_base to NULL to create a new translation table for the SMMU */
+      smmu_pgt_desc.pgt_base = (uint64_t) NULL;
+      if (val_pgt_create(mem_desc, &smmu_pgt_desc)) {
             val_print(ACS_PRINT_ERR,
                       " Unable to create page table with given attributes", 0);
             goto test_fail;
@@ -344,11 +352,12 @@ payload (void)
 
       /* Configure the SMMU tables for this exerciser to use this page table
          for VA to PA translations*/
-      if (val_smmu_map(master, pgt_desc))
+      if (val_smmu_map(master, smmu_pgt_desc))
       {
             val_print(ACS_PRINT_ERR, " SMMU mapping failed (%x)     ", e_bdf);
             goto test_fail;
       }
+      smmu_mapped = 1;
     }
 
     /* Configure Exerciser to issue subsequent DMA transactions with Address Translated bit Set */
@@ -364,13 +373,15 @@ test_fail:
     val_set_status(pe_index, "FAIL", 02);
 
 test_clean:
-  val_smmu_unmap(master);
+  if (smmu_mapped)
+      val_smmu_unmap(master);
 
-  if (pgt_desc.pgt_base != (uint64_t) NULL) {
-      val_pgt_destroy(pgt_desc);
+  if (smmu_pgt_desc.pgt_base != (uint64_t) NULL) {
+      val_pgt_destroy(smmu_pgt_desc);
   }
 
-  if (val_pcie_find_capability(e_bdf, PCIE_ECAP, ECID_ATS, &cap_base) == PCIE_SUCCESS)
+  if (exerciser_ready &&
+      (val_pcie_find_capability(e_bdf, PCIE_ECAP, ECID_ATS, &cap_base) == PCIE_SUCCESS))
   {
         val_pcie_read_cfg(e_bdf, cap_base + ATS_CTRL, &reg_value);
         reg_value &= ATS_CACHING_DIS;

--- a/test_pool/smmu/smmu_responds_to_gpt_tlb.c
+++ b/test_pool/smmu/smmu_responds_to_gpt_tlb.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2024, 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2024, 2025-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,41 +53,46 @@ void
 payload(void)
 {
   uint32_t pe_index;
-  uint32_t dma_len, attr;
-  uint32_t instance;
-  uint32_t e_bdf;
-  uint32_t cap_base;
-  void *dram_buf_in_virt;
-  void *dram_buf_out_virt;
-  uint64_t dram_buf_in_phys;
-  uint64_t dram_buf_out_phys;
-  uint64_t dram_buf_in_iova;
-  uint64_t dram_buf_out_iova;
+  uint32_t dma_len = 0, attr = 0;
+  uint32_t instance = 0;
+  uint32_t e_bdf = 0;
+  uint32_t cap_base = 0;
+  void *dram_buf_in_virt = NULL;
+  void *dram_buf_out_virt = NULL;
+  uint64_t dram_buf_in_phys = 0;
+  uint64_t dram_buf_out_phys = 0;
+  uint64_t dram_buf_in_iova = 0;
+  uint64_t dram_buf_out_iova = 0;
   uint32_t num_smmus;
   uint32_t device_id, its_id;
   uint32_t page_size = val_memory_page_size();
   memory_region_descriptor_t mem_desc_array[2], *mem_desc;
-  pgt_descriptor_t pgt_desc;
+  pgt_descriptor_t cpu_pgt_desc;
+  pgt_descriptor_t smmu_pgt_desc;
   smmu_master_attributes_t master;
-  uint64_t ttbr;
+  uint64_t ttbr = 0;
   uint32_t test_data_blk_size = page_size * TEST_DATA_NUM_PAGES;
   uint32_t reg_value = 0;
   uint64_t size;
+  uint32_t exerciser_ready = 0;
+  uint32_t smmu_mapped = 0;
 
   /* Enable all SMMUs */
   num_smmus = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
 
   /* Initialize DMA master and memory descriptors */
   val_memory_set(&master, sizeof(master), 0);
+  master.smmu_index = ACS_INVALID_INDEX;
   val_memory_set(mem_desc_array, sizeof(mem_desc_array), 0);
+  val_memory_set(&cpu_pgt_desc, sizeof(cpu_pgt_desc), 0);
+  val_memory_set(&smmu_pgt_desc, sizeof(smmu_pgt_desc), 0);
   mem_desc = &mem_desc_array[0];
-  dram_buf_in_phys = 0;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   /* Get translation attributes via TCR and translation table base via TTBR */
   if (val_pe_reg_read_tcr(0 /*for TTBR0*/,
-                          &pgt_desc.tcr)) {
+                          &cpu_pgt_desc.tcr)) {
     val_print(ACS_PRINT_ERR, " TCR read failure", 0);
     goto test_fail;
   }
@@ -106,6 +111,7 @@ payload(void)
   /* if init fail moves to next exerciser */
   if (val_exerciser_init(instance))
         goto test_fail;
+  exerciser_ready = 1;
 
   /* Get exerciser bdf */
   e_bdf = val_exerciser_get_bdf(instance);
@@ -143,17 +149,17 @@ payload(void)
   reg_value |= ATS_CACHING_EN;
   val_pcie_write_cfg(e_bdf, cap_base + ATS_CTRL, reg_value);
 
-  pgt_desc.pgt_base = (ttbr & AARCH64_TTBR_ADDR_MASK);
-  pgt_desc.mair = val_pe_reg_read(MAIR_ELx);
-  pgt_desc.stage = PGT_STAGE1;
-  pgt_desc.ias = 48;
-  pgt_desc.oas = 48;
+  cpu_pgt_desc.pgt_base = (ttbr & AARCH64_TTBR_ADDR_MASK);
+  cpu_pgt_desc.mair = val_pe_reg_read(MAIR_ELx);
+  cpu_pgt_desc.stage = PGT_STAGE1;
+  cpu_pgt_desc.ias = 48;
+  cpu_pgt_desc.oas = 48;
   mem_desc->virtual_address = (uint64_t)dram_buf_in_virt;
   mem_desc->physical_address = dram_buf_in_phys;
   mem_desc->length = test_data_blk_size;
   mem_desc->attributes |= (PGT_STAGE1_AP_RW);
 
-  if (val_pgt_create(mem_desc, &pgt_desc)) {
+  if (val_pgt_create(mem_desc, &cpu_pgt_desc)) {
         val_print(ACS_PRINT_ERR,
                       " Unable to create page table with given attributes", 0);
             goto test_fail;
@@ -163,7 +169,7 @@ payload(void)
   /* Get memory attributes of the test buffer, we'll use the same attibutes to create
    * our own page table later.
    */
-  if (val_pgt_get_attributes(pgt_desc, (uint64_t)dram_buf_in_virt, &mem_desc->attributes)) {
+  if (val_pgt_get_attributes(cpu_pgt_desc, (uint64_t)dram_buf_in_virt, &mem_desc->attributes)) {
         val_print(ACS_PRINT_ERR, " Unable to get memory attributes of the test buffer", 0);
         goto test_fail;
   }
@@ -206,24 +212,24 @@ payload(void)
       val_data_cache_ops_by_va((uint64_t)dram_buf_in_virt, CLEAN_AND_INVALIDATE);
 
       /* Need to know input and output address sizes before creating page table */
-      pgt_desc.ias = val_smmu_get_info(SMMU_IN_ADDR_SIZE, master.smmu_index);
-      if ((pgt_desc.ias) == 0) {
+      smmu_pgt_desc = cpu_pgt_desc;
+      smmu_pgt_desc.ias = val_smmu_get_info(SMMU_IN_ADDR_SIZE, master.smmu_index);
+      if ((smmu_pgt_desc.ias) == 0) {
             val_print(ACS_PRINT_ERR,
                           " Input address size of SMMU %d is 0", master.smmu_index);
             goto test_fail;
       }
 
-      pgt_desc.oas = val_smmu_get_info(SMMU_OUT_ADDR_SIZE, master.smmu_index);
-      if ((pgt_desc.oas) == 0) {
+      smmu_pgt_desc.oas = val_smmu_get_info(SMMU_OUT_ADDR_SIZE, master.smmu_index);
+      if ((smmu_pgt_desc.oas) == 0) {
             val_print(ACS_PRINT_ERR,
                           " Output address size of SMMU %d is 0", master.smmu_index);
             goto test_fail;
       }
 
-      /* set pgt_desc.pgt_base to NULL to create new translation table, val_pgt_create
-         will update pgt_desc.pgt_base to point to created translation table */
-      pgt_desc.pgt_base = (uint64_t) NULL;
-      if (val_pgt_create(mem_desc, &pgt_desc)) {
+      /* set pgt_base to NULL to create a new translation table for the SMMU */
+      smmu_pgt_desc.pgt_base = (uint64_t) NULL;
+      if (val_pgt_create(mem_desc, &smmu_pgt_desc)) {
             val_print(ACS_PRINT_ERR,
                       " Unable to create page table with given attributes", 0);
             goto test_fail;
@@ -231,11 +237,12 @@ payload(void)
 
       /* Configure the SMMU tables for this exerciser to use this page table
          for VA to PA translations*/
-      if (val_smmu_map(master, pgt_desc))
+      if (val_smmu_map(master, smmu_pgt_desc))
       {
             val_print(ACS_PRINT_ERR, " SMMU mapping failed (%x)     ", e_bdf);
             goto test_fail;
       }
+      smmu_mapped = 1;
 
       dram_buf_in_iova = mem_desc->virtual_address;
       dram_buf_out_iova = dram_buf_in_iova + (test_data_blk_size / 2);
@@ -310,14 +317,15 @@ test_fail:
   val_set_status(pe_index, "FAIL", 01);
 
 test_clean:
-  if (val_add_gpt_entry_el3(dram_buf_in_phys, GPT_ANY))
+  if ((dram_buf_in_phys != 0u) && val_add_gpt_entry_el3(dram_buf_in_phys, GPT_ANY))
   {
       val_print(ACS_PRINT_ERR,
                   " test_clean: Failed to clear GPT entry for PA 0x%llx", dram_buf_in_phys);
       val_set_status(pe_index, "FAIL", 02);
   }
 
-  if (val_add_mmu_entry_el3((uint64_t)dram_buf_in_virt, dram_buf_in_phys,
+  if ((dram_buf_in_virt != NULL) && (dram_buf_in_phys != 0u) &&
+      val_add_mmu_entry_el3((uint64_t)dram_buf_in_virt, dram_buf_in_phys,
                   (attr | LOWER_ATTRS(PAS_ATTR(NONSECURE_PAS)))))
   {
       val_print(ACS_PRINT_ERR,
@@ -326,29 +334,28 @@ test_clean:
   }
 
   //Clear the memory
-  if (val_memory_set_el3((uint64_t *)dram_buf_in_virt, dma_len/2, 0))
+  if ((dram_buf_in_virt != NULL) && (dma_len != 0u) &&
+      val_memory_set_el3((uint64_t *)dram_buf_in_virt, dma_len/2, 0))
   {
       val_print(ACS_PRINT_ERR, " test_clean: Failed to set memory to 0 ", 0);
       val_set_status(pe_index, "FAIL", 04);
   }
   //Clean and invalidate the memory
-  if (val_data_cache_ops_by_va_el3((uint64_t)dram_buf_in_virt, CLEAN_AND_INVALIDATE))
+  if ((dram_buf_in_virt != NULL) &&
+      val_data_cache_ops_by_va_el3((uint64_t)dram_buf_in_virt, CLEAN_AND_INVALIDATE))
   {
       val_print(ACS_PRINT_ERR, " test_clean: Failed to clean and invalidate dram_buf_in", 0);
       val_set_status(pe_index, "FAIL", 05);
   }
 
-  /* Remove all address mappings for this exerciser */
-  e_bdf = val_exerciser_get_bdf(instance);
-  master.smmu_index = val_iovirt_get_rc_smmu_index(PCIE_EXTRACT_BDF_SEG(e_bdf),
-                                                   PCIE_CREATE_BDF_PACKED(e_bdf));
+  if (smmu_mapped)
+      val_smmu_unmap(master);
 
-  val_smmu_unmap(master);
+  if (smmu_pgt_desc.pgt_base != (uint64_t) NULL)
+      val_pgt_destroy(smmu_pgt_desc);
 
-  if (pgt_desc.pgt_base != (uint64_t) NULL)
-      val_pgt_destroy(pgt_desc);
-
-  if (val_pcie_find_capability(e_bdf, PCIE_ECAP, ECID_ATS, &cap_base) == PCIE_SUCCESS)
+  if (exerciser_ready &&
+      (val_pcie_find_capability(e_bdf, PCIE_ECAP, ECID_ATS, &cap_base) == PCIE_SUCCESS))
   {
         val_pcie_read_cfg(e_bdf, cap_base + ATS_CTRL, &reg_value);
         reg_value &= ATS_CACHING_DIS;
@@ -378,4 +385,3 @@ smmu_responds_to_gpt_tlb_entry(void)
 
   return status;
 }
-

--- a/val/include/val_el32.h
+++ b/val/include/val_el32.h
@@ -121,10 +121,10 @@
 #define EXTRACT_ATTR_IND(x)   ((MAIR_REG_VAL_EL3 >> (x * 8)) & 0xFF)
 #define GET_ATTR_INDEX(x)           \
   ({                                \
-    int index;                      \
+    int index = 0;                  \
     for (int i = 0; i < 8; ++i)     \
     {                               \
-      if (EXTRACT_ATTR_IND(i) == x) \
+      if (EXTRACT_ATTR_IND(i) == (x)) \
       {                             \
         index = i;                  \
         break;                      \

--- a/val/src/val_memory.c
+++ b/val/src/val_memory.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2022-2023, 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2022-2023, 2025-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@
 #include "include/val_memory.h"
 #include "include/val_pgt.h"
 #include "include/val_interface.h"
+#include "include/val_pe.h"
 #include "include/val_el32.h"
 
 void *
@@ -232,7 +233,7 @@ uint32_t val_setup_mmu(void)
 **/
 uint32_t val_enable_mmu(void)
 {
-    uint64_t tcr;
+    uint64_t tcr = val_pe_reg_read(TCR_ELx);
     uint32_t currentEL;
     currentEL = (val_read_current_el() & 0xc) >> 2;
 
@@ -334,4 +335,3 @@ val_strnlen(const char8_t *str)
     len++;
   return len;
 }
-

--- a/val/src/val_pcie.c
+++ b/val/src/val_pcie.c
@@ -3019,6 +3019,8 @@ val_pcie_get_bar_index(uint32_t bdf, uint64_t bar_address, uint32_t *bar_index)
     uint64_t base_address;
 
     while (index < TYPE0_MAX_BARS) {
+        base_address = 0u;
+
         /* Read the base address register at loop index */
         val_pcie_read_cfg(bdf, TYPE01_BAR + index * 4, &bar_low32bits);
 
@@ -3026,6 +3028,9 @@ val_pcie_get_bar_index(uint32_t bdf, uint64_t bar_address, uint32_t *bar_index)
         if (((bar_low32bits >> BAR_MIT_SHIFT) & BAR_MIT_MASK) == MMIO) {
             /* Check if the BAR is 64-bit decodable */
             if (((bar_low32bits >> BAR_MDT_SHIFT) & BAR_MDT_MASK) == BITS_64) {
+                if ((index + 1u) >= TYPE0_MAX_BARS)
+                    return 1;
+
                 /* Read the second sequential BAR at next index */
                 val_pcie_read_cfg(bdf, TYPE01_BAR + (index + 1) * 4, &bar_high32bits);
 
@@ -3039,6 +3044,9 @@ val_pcie_get_bar_index(uint32_t bdf, uint64_t bar_address, uint32_t *bar_index)
             } else if (((bar_low32bits >> BAR_MDT_SHIFT) & BAR_MDT_MASK) == BITS_32) {
                 /* Use only lower 32-bits for 32-bit BAR */
                 base_address = ((bar_low32bits) & (BAR_BASE_MASK << BAR_BASE_SHIFT));
+            } else {
+                index++;
+                continue;
             }
 
             /* Check if the given BAR address matches this base address */


### PR DESCRIPTION
  Address the actionable Coverity issues reported for the RME ACS
  sources.

  - initialize GET_ATTR_INDEX() fallback state to avoid repeated UNINIT reports across MMU attribute users
  - fix pal_pci_bdf_to_dev() returning a pointer to stack storage
  - initialize local counters/addresses before use in legacy TZ and MMU paths
  - harden BAR index lookup and RP/EP discovery before TDISP handling
  - guard SMMU/page-table/ATS cleanup so teardown only runs after setup succeeds in the RME and SMMU tests

  This resolves the local Coverity findings from coverity_reports.
  Third-party findings under ext/libspdm are not changed here.


Change-Id: I2f6eaaa27a305dac27e612e516ae47715058674f