### PR TITLE
fix: prevent 64-bit truncation and stabilize RME watchdog/SMC flows

### DIFF
--- a/platform/pal_baremetal/FVP/include/pal_override_struct.h
+++ b/platform/pal_baremetal/FVP/include/pal_override_struct.h
@@ -298,8 +298,8 @@ typedef struct {
   @brief  structure instance for Region details
 **/
 typedef struct {
-  uint32_t   base_addr;
-  uint32_t   regn_size;
+  uint64_t   base_addr;
+  uint64_t   regn_size;
   uint64_t   resourse_pas;
 } MEM_REGN_INFO_ENTRY;
 

--- a/platform/pal_uefi/include/pal_uefi.h
+++ b/platform/pal_uefi/include/pal_uefi.h
@@ -99,8 +99,8 @@ typedef struct
 **/
 typedef struct
 {
-  UINT32 base_addr;
-  UINT32 regn_size;
+  UINT64 base_addr;
+  UINT64 regn_size;
   UINT64 resourse_pas;
 } MEM_REGN_INFO_ENTRY;
 

--- a/platform/pal_uefi/src/pal_plat_cfg.c
+++ b/platform/pal_uefi/src/pal_plat_cfg.c
@@ -763,8 +763,8 @@ VOID pal_mem_region_create_info_table(MEM_REGN_INFO_TABLE* gpc_table,
     UINT64 size = RmeCfgGetU64(key, def_size);
     UnicodeSPrint(key, sizeof(key), L"GPC_PROTECTED_REGION_%u_PAS", i);
     UINT64 pas                   = RmeCfgGetU64(key, def_pas);
-    pal_gpc_regs[i].base_addr    = (UINT32)base;
-    pal_gpc_regs[i].regn_size    = (UINT32)size;
+    pal_gpc_regs[i].base_addr    = base;
+    pal_gpc_regs[i].regn_size    = size;
     pal_gpc_regs[i].resourse_pas = pas;
     gpc_table->regn_info[i]      = pal_gpc_regs[i];
   }
@@ -808,8 +808,8 @@ VOID pal_mem_region_create_info_table(MEM_REGN_INFO_TABLE* gpc_table,
     UINT64 size = RmeCfgGetU64(key, def_size);
     UnicodeSPrint(key, sizeof(key), L"PAS_PROTECTED_REGION_%u_PAS", i);
     UINT64 pas                   = RmeCfgGetU64(key, def_pas);
-    pal_pas_regs[i].base_addr    = (UINT32)base;
-    pal_pas_regs[i].regn_size    = (UINT32)size;
+    pal_pas_regs[i].base_addr    = base;
+    pal_pas_regs[i].regn_size    = size;
     pal_pas_regs[i].resourse_pas = pas;
     pas_table->regn_info[i]      = pal_pas_regs[i];
   }

--- a/test_pool/da/da_attribute_rmeda_ctl_registers.c
+++ b/test_pool/da/da_attribute_rmeda_ctl_registers.c
@@ -52,7 +52,7 @@ payload()
   uint32_t reg_value, write_val, ide_reg_value;
   uint32_t original_reg_val;
   uint64_t va;
-  uint32_t cfg_addr;
+  uint64_t cfg_addr;
   uint32_t pgt_attr_el3;
   uint32_t pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
   uint32_t test_fails = 0;

--- a/test_pool/da/da_incoming_request_ide_sec_locked.c
+++ b/test_pool/da/da_incoming_request_ide_sec_locked.c
@@ -56,7 +56,7 @@ payload(void)
   uint32_t sel_str_lock_bit;
   uint32_t stream_id;
   uint32_t pgt_attr_el3;
-  uint32_t cfg_addr;
+  uint64_t cfg_addr;
   uint32_t str_index;
   uint32_t device_id, its_id;
   uint32_t page_size = val_memory_page_size();

--- a/test_pool/da/da_selective_ide_register_property.c
+++ b/test_pool/da/da_selective_ide_register_property.c
@@ -67,7 +67,7 @@ payload(void)
   uint32_t pgt_attr_el3;
   uint32_t sel_str_lock_bit;
   uint64_t va;
-  uint32_t cfg_addr;
+  uint64_t cfg_addr;
   uint32_t da_cap_base;
   uint32_t stream_id;
   uint32_t str_index;

--- a/test_pool/dpt/dpt_p2p_different_rootport_invalid.c
+++ b/test_pool/dpt/dpt_p2p_different_rootport_invalid.c
@@ -124,7 +124,7 @@ payload(void)
   uint32_t sel_str_lock_bit;
   uint32_t stream_id;
   uint32_t pgt_attr_el3;
-  uint32_t cfg_addr;
+  uint64_t cfg_addr;
   uint32_t str_index;
   uint32_t device_id, its_id;
   uint32_t page_size = val_memory_page_size();

--- a/test_pool/dpt/dpt_p2p_different_rootport_valid.c
+++ b/test_pool/dpt/dpt_p2p_different_rootport_valid.c
@@ -124,7 +124,7 @@ payload(void)
   uint32_t sel_str_lock_bit;
   uint32_t stream_id;
   uint32_t pgt_attr_el3;
-  uint32_t cfg_addr;
+  uint64_t cfg_addr;
   uint32_t str_index;
   uint32_t device_id, its_id;
   uint32_t page_size = val_memory_page_size();

--- a/test_pool/dpt/dpt_p2p_same_rootport_invalid.c
+++ b/test_pool/dpt/dpt_p2p_same_rootport_invalid.c
@@ -124,7 +124,7 @@ payload(void)
   uint32_t sel_str_lock_bit;
   uint32_t stream_id;
   uint32_t pgt_attr_el3;
-  uint32_t cfg_addr;
+  uint64_t cfg_addr;
   uint32_t str_index;
   uint32_t device_id, its_id;
   uint32_t page_size = val_memory_page_size();

--- a/test_pool/dpt/dpt_p2p_same_rootport_valid.c
+++ b/test_pool/dpt/dpt_p2p_same_rootport_valid.c
@@ -124,7 +124,7 @@ payload(void)
   uint32_t sel_str_lock_bit;
   uint32_t stream_id;
   uint32_t pgt_attr_el3;
-  uint32_t cfg_addr;
+  uint64_t cfg_addr;
   uint32_t str_index;
   uint32_t device_id, its_id;
   uint32_t page_size = val_memory_page_size();

--- a/test_pool/dpt/dpt_system_resource_invalid.c
+++ b/test_pool/dpt/dpt_system_resource_invalid.c
@@ -49,7 +49,7 @@ payload(void)
   uint32_t sel_str_lock_bit;
   uint32_t stream_id;
   uint32_t pgt_attr_el3;
-  uint32_t cfg_addr;
+  uint64_t cfg_addr;
   uint32_t str_index;
   uint32_t device_id, its_id;
   uint32_t page_size = val_memory_page_size();

--- a/test_pool/dpt/dpt_system_resource_valid_with_dpti.c
+++ b/test_pool/dpt/dpt_system_resource_valid_with_dpti.c
@@ -49,7 +49,7 @@ payload(void)
   uint32_t sel_str_lock_bit;
   uint32_t stream_id;
   uint32_t pgt_attr_el3;
-  uint32_t cfg_addr;
+  uint64_t cfg_addr;
   uint32_t str_index;
   uint32_t device_id, its_id;
   uint32_t page_size = val_memory_page_size();

--- a/test_pool/dpt/dpt_system_resource_valid_without_dpti.c
+++ b/test_pool/dpt/dpt_system_resource_valid_without_dpti.c
@@ -49,7 +49,7 @@ payload(void)
   uint32_t sel_str_lock_bit;
   uint32_t stream_id;
   uint32_t pgt_attr_el3;
-  uint32_t cfg_addr;
+  uint64_t cfg_addr;
   uint32_t str_index;
   uint32_t device_id, its_id;
   uint32_t page_size = val_memory_page_size();

--- a/test_pool/rme/rme_root_wdog_fails_in_non_root_state.c
+++ b/test_pool/rme/rme_root_wdog_fails_in_non_root_state.c
@@ -99,7 +99,8 @@ static void payload(void)
 
   VA_RT_WDOG  = val_get_free_va(size);
   rt_wdog_ctl = val_get_rt_wdog_ctrl();
-  attr        = LOWER_ATTRS(PGT_ENTRY_ACCESS | SHAREABLE_ATTR(NON_SHAREABLE) | PGT_ENTRY_AP_RW);
+  attr        = LOWER_ATTRS(PGT_ENTRY_ACCESS | SHAREABLE_ATTR(NON_SHAREABLE) |
+                            PGT_ENTRY_AP_RW | GET_ATTR_INDEX(DEV_MEM_nGnRnE));
   if (val_add_mmu_entry_el3(VA_RT_WDOG, rt_wdog_ctl, (attr | LOWER_ATTRS(PAS_ATTR(NONSECURE_PAS)))))
   {
     val_print(ACS_PRINT_ERR, " Failed to map RT_WDOG_CTRL register in MMU", 0);

--- a/test_pool/rme/rme_root_wdog_fails_in_non_root_state.c
+++ b/test_pool/rme/rme_root_wdog_fails_in_non_root_state.c
@@ -125,6 +125,9 @@ static void payload(void)
   if (IS_RESULT_PENDING(val_get_status(index)))
   {
     val_print(ACS_PRINT_DEBUG, " WS0 Interrupt not received on %d", int_id);
+    shared_data->generic_flag = CLEAR;
+    shared_data->exception_expected = CLEAR;
+    shared_data->exception_generated = CLEAR;
     val_set_status(index, "PASS", 3);
     return;
   }

--- a/test_pool/rme/rme_root_wdog_from_root_pas.c
+++ b/test_pool/rme/rme_root_wdog_from_root_pas.c
@@ -100,7 +100,8 @@ payload()
     val_gic_set_intr_trigger(int_id, INTR_TRIGGER_INFO_LEVEL_HIGH);
 
     shared_data->generic_flag = CLEAR;
-    attr = LOWER_ATTRS(PGT_ENTRY_ACCESS | SHAREABLE_ATTR(NON_SHAREABLE) | PGT_ENTRY_AP_RW);
+    attr = LOWER_ATTRS(PGT_ENTRY_ACCESS | SHAREABLE_ATTR(NON_SHAREABLE) | PGT_ENTRY_AP_RW
+                       | GET_ATTR_INDEX(DEV_MEM_nGnRnE));
     if (val_add_mmu_entry_el3(VA_RT_WDOG, rt_wdog_ctl_reg,
                                 (attr | LOWER_ATTRS(PAS_ATTR(ROOT_PAS)))))
     {

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -864,8 +864,8 @@ typedef struct {
   @brief  structure instance for Region details
 **/
 typedef struct {
-  uint32_t base_addr;
-  uint32_t regn_size;
+  uint64_t base_addr;
+  uint64_t regn_size;
   uint64_t resourse_pas;
 } MEM_REGN_INFO_ENTRY;
 

--- a/val/include/val_el32.h
+++ b/val/include/val_el32.h
@@ -88,7 +88,7 @@
 #define DISABLE_MEC  0x3
 
 /* Defines related to PGT attrinutes of an address */
-#define MAIR_REG_VAL_EL3 0x00000000004404ff
+#define MAIR_REG_VAL_EL3 0x00000000004400ff
 
 #define GPT_SECURE      0x8
 #define GPT_NONSECURE   0x9

--- a/val/src/AArch64/PeTestSupport.S
+++ b/val/src/AArch64/PeTestSupport.S
@@ -1,5 +1,5 @@
 #/** @file
-# Copyright (c) 2022-2023, 2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2022-2023, 2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -102,9 +102,19 @@ ASM_PFX(set_daif):
   ret
 
 ASM_PFX(UserCallSMC):
-  stp x29, x30, [sp, #-0x10]!
+  stp x19, x20, [sp, #-0x60]!
+  stp x21, x22, [sp, #0x10]
+  stp x23, x24, [sp, #0x20]
+  stp x25, x26, [sp, #0x30]
+  stp x27, x28, [sp, #0x40]
+  stp x29, x30, [sp, #0x50]
   smc #0
-  ldp x29,x30, [sp] ,#0x10
+  ldp x19, x20, [sp], #0x10
+  ldp x21, x22, [sp], #0x10
+  ldp x23, x24, [sp], #0x10
+  ldp x25, x26, [sp], #0x10
+  ldp x27, x28, [sp], #0x10
+  ldp x29, x30, [sp], #0x10
   ret
 
 ASM_PFX(ArmCallWFI):


### PR DESCRIPTION
- Widen MEM_REGN_INFO_ENTRY base_addr/regn_size to 64-bit across VAL/UEFI/baremetal and drop narrowing casts to avoid truncating 64-bit region addresses/sizes (e.g., GPC/PAS).
- Use uint64_t for local cfg_addr variables in affected DA/DPT tests to avoid truncation of PCIe config-space addresses returned by val_pcie_get_bdf_config_addr() on high address ranges.
- Preserve callee-saved registers (x19–x30) in the UserCallSMC wrapper to prevent caller-context corruption across EL3 round-trips.
- Map RT_WDOG_CTRL as device memory (DEV_MEM_nGnRnE) and align MAIR_REG_VAL_EL3 encoding so watchdog mappings aren’t treated as normal memory.
- Clear shared exception-state flags after the non-root watchdog negative test to prevent stale state leaking into subsequent tests and causing false failures