### PR TITLE
val/timer: allow PAL to override counter frequency

### DIFF
--- a/platform/pal_baremetal/src/pal_timer_wd.c
+++ b/platform/pal_baremetal/src/pal_timer_wd.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2022-2023, 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2022-2023, 2025-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,7 @@
  * limitations under the License.
 **/
 
-#include "FVP/include/pal_override_struct.h"
+#include "pal_override_struct.h"
 #include "include/pal_common_support.h"
 
 extern PLATFORM_OVERRIDE_TIMER_INFO_TABLE platform_timer_cfg;

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -300,6 +300,8 @@ typedef struct {
 
 void pal_timer_create_info_table(TIMER_INFO_TABLE *timer_info_table);
 
+uint64_t pal_timer_get_counter_frequency(void);
+
 /* PCIe Tests related definitions */
 
 /**

--- a/val/src/val_timer.c
+++ b/val/src/val_timer.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2022-2023, 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2022-2023, 2025-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,7 +45,14 @@ val_timer_get_info(TIMER_INFO_e info_type, uint64_t instance)
   switch (info_type)
   {
       case TIMER_INFO_CNTFREQ:
+      {
+          uint64_t counter_frequency = pal_timer_get_counter_frequency();
+
+          if (counter_frequency != 0)
+              return counter_frequency;
+
           return val_timer_ArmArchTimerReadReg(CntFrq);
+      }
       case TIMER_INFO_PHY_EL1_INTID:
           return g_timer_info_table->header.ns_el1_timer_gsiv;
       case TIMER_INFO_VIR_EL1_INTID:


### PR DESCRIPTION
Add a PAL hook for retrieving the timer counter frequency and use it for TIMER_INFO_CNTFREQ when available. Fall back to reading CNTFRQ directly when the PAL does not provide a frequency.