### PR TITLE
val_el3: clear stale exception_expected after PAS filter load

### DIFF
--- a/val_el3/src/aarch64/val_el3_helper_functions.S
+++ b/val_el3/src/aarch64/val_el3_helper_functions.S
@@ -175,6 +175,7 @@ val_el3_acs_ldr_pas_filter:
        ldr    x1, [x0]
        dsb    sy
        ldr    x0, =PLAT_SHARED_ADDRESS
+       str    xzr, [x0, #0x18]
        ldr    x2, [x0, #0x8]
        ldr    x3, [x0, #0x10]
        msr    elr_el3, x2


### PR DESCRIPTION
When exception_expected is set before a PAS-filtered EL3 load, the access may complete without generating an exception. In that path, val_el3_acs_ldr_pas_filter restored the saved EL3 state without clearing exception_expected, leaving stale shared exception state for later exception handling.

Clear exception_expected after the PAS-filtered load completes and before restoring ELR_EL3/SPSR_EL3.