### PR TITLE
tools: shrinkwrap - use shallow clone for DT source

### DIFF
--- a/tools/configs/shrinkwrap/rme-acs-stack-base.yaml
+++ b/tools/configs/shrinkwrap/rme-acs-stack-base.yaml
@@ -58,6 +58,11 @@ build:
     postbuild:
       - rm -rf .rmm_venv
 
+  dt:
+    repo:
+      remote:  --depth 1 --branch v6.17-dts https://git.kernel.org/pub/scm/linux/kernel/git/devicetree/devicetree-rebasing.git
+      revision: v6.17-dts
+
 buildex:
   btvars:
     ACS_PATH:


### PR DESCRIPTION
Add the devicetree repository to the RME ACS stack base shrinkwrap config with a depth-1 clone pinned to v6.17-dts. This avoids the slow full clone of the DT source while keeping the build input fixed.