### PR TITLE
val_el3: clear stale exception_expected after store access

### DIFF
--- a/val_el3/src/aarch64/val_el3_helper_functions.S
+++ b/val_el3/src/aarch64/val_el3_helper_functions.S
@@ -136,6 +136,7 @@ val_el3_acs_str:
        str    x1, [x0]
        dsb    sy
        ldr    x0, =PLAT_SHARED_ADDRESS
+       str    xzr, [x0, #0x18]
        ldr    x1, [x0, #0x8]
        ldr    x2, [x0, #0x10]
        msr    elr_el3, x1


### PR DESCRIPTION
val_el3_acs_str() handles expected-exception store accesses. If the store completes without taking an exception, exception_expected can remain set and affect later exception handling.

Clear it before restoring ELR_EL3/SPSR_EL3.