### PR TITLE
fix(test): avoid false passes when prerequisites are absent

### DIFF
--- a/test_pool/da/da_attribute_rmeda_ctl_registers.c
+++ b/test_pool/da/da_attribute_rmeda_ctl_registers.c
@@ -66,6 +66,12 @@ payload()
 
   tbl_index = 0;
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  if ((bdf_tbl_ptr == NULL) || (bdf_tbl_ptr->num_entries == 0))
+  {
+      val_print(ACS_PRINT_WARN, " No PCIe BDF entries discovered", 0);
+      val_set_status(pe_index, "SKIP", 01);
+      return;
+  }
 
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {

--- a/test_pool/da/da_autonomous_rootport_request_ns_pas.c
+++ b/test_pool/da/da_autonomous_rootport_request_ns_pas.c
@@ -88,6 +88,12 @@ payload(void)
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
   instance = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  if (instance == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+    val_set_status(pe_index, "SKIP", 01);
+    return;
+  }
 
   while (instance-- != 0) {
 

--- a/test_pool/da/da_ctl_regs_rmsd_write_protect_property.c
+++ b/test_pool/da/da_ctl_regs_rmsd_write_protect_property.c
@@ -49,12 +49,17 @@ payload()
 
   tbl_index = 0;
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  if ((bdf_tbl_ptr == NULL) || (bdf_tbl_ptr->num_entries == 0))
+  {
+      val_print(ACS_PRINT_WARN, " No PCIe BDF entries discovered", 0);
+      val_set_status(pe_index, "SKIP", 01);
+      return;
+  }
+
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {
       bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
       dp_type = val_pcie_device_port_type(bdf);
-
-      test_skip = 0;
 
       if (dp_type == RP)
       {
@@ -63,20 +68,20 @@ payload()
           /* Get the PCIE DVSEC Capability register */
           if (val_pcie_find_da_capability(bdf, &da_cap_base) != PCIE_SUCCESS)
           {
-              val_print(ACS_PRINT_ERR,
+              val_print(ACS_PRINT_WARN,
                               " PCIe DA DVSEC capability not present,bdf 0x%x", bdf);
-              test_fails++;
               continue;
           }
 
           /* Get the PCIE IDE Extended Capability register */
           if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_IDE, &ide_cap_base) != PCIE_SUCCESS)
           {
-              val_print(ACS_PRINT_ERR,
+              val_print(ACS_PRINT_WARN,
                               " PCIe IDE Capability not present for BDF: 0x%x", bdf);
-              test_fails++;
               continue;
           }
+
+          test_skip = 0;
 
           /* Read the RMEDA_CTL registers */
           val_pcie_read_cfg(bdf, da_cap_base + RMEDA_CTL1, &reg_ctl1);

--- a/test_pool/da/da_dvsec_register_config.c
+++ b/test_pool/da/da_dvsec_register_config.c
@@ -40,7 +40,13 @@ payload(void)
                                           table_entries,
                                           VAL_DVSEC_SELECT_RMEDA);
 
-  if (ret)
+  if (ret == ACS_STATUS_SKIP)
+  {
+      val_print(ACS_PRINT_TEST,
+                " No PCIe RME-DA DVSEC instances discovered, skipping", 0);
+      val_set_status(pe_index, "SKIP", 01);
+  }
+  else if (ret != 0u)
       val_set_status(pe_index, "FAIL", 01);
   else
       val_set_status(pe_index, "PASS", 01);

--- a/test_pool/da/da_ide_state_rootport_error.c
+++ b/test_pool/da/da_ide_state_rootport_error.c
@@ -69,6 +69,12 @@ payload()
   uint32_t status;
 
   instance = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  if (instance == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+    val_set_status(pe_index, "SKIP", 01);
+    return;
+  }
 
   while (instance-- != 0) {
 

--- a/test_pool/da/da_ide_state_tdisp_disable.c
+++ b/test_pool/da/da_ide_state_tdisp_disable.c
@@ -52,6 +52,12 @@ payload(void)
   tbl_index = 0;
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  if ((bdf_tbl_ptr == NULL) || (bdf_tbl_ptr->num_entries == 0))
+  {
+      val_print(ACS_PRINT_WARN, " No PCIe BDF entries discovered", 0);
+      val_set_status(pe_index, "SKIP", 01);
+      return;
+  }
 
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {

--- a/test_pool/da/da_ide_tbit_0_for_root_request.c
+++ b/test_pool/da/da_ide_tbit_0_for_root_request.c
@@ -56,6 +56,12 @@ payload(void)
   tbl_index = 0;
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  if ((bdf_tbl_ptr == NULL) || (bdf_tbl_ptr->num_entries == 0))
+  {
+      val_print(ACS_PRINT_WARN, " No PCIe BDF entries discovered", 0);
+      val_set_status(pe_index, "SKIP", 01);
+      return;
+  }
 
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {

--- a/test_pool/da/da_incoming_request_ide_non_sec_unlocked.c
+++ b/test_pool/da/da_incoming_request_ide_non_sec_unlocked.c
@@ -56,6 +56,12 @@ payload(void)
   dma_len = test_data_blk_size / 2;
 
   num_exercisers = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  if (num_exercisers == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+    val_set_status(pe_index, "SKIP", 01);
+    return;
+  }
 
   for (instance = 0; instance < num_exercisers; ++instance)
   {

--- a/test_pool/da/da_incoming_request_ide_sec_locked.c
+++ b/test_pool/da/da_incoming_request_ide_sec_locked.c
@@ -71,6 +71,12 @@ payload(void)
   dma_len = test_data_blk_size / 2;
 
   num_exercisers = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  if (num_exercisers == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+    val_set_status(pe_index, "SKIP", 01);
+    return;
+  }
 
   /* Initialize DMA master and memory descriptors */
   val_memory_set(&master, sizeof(master), 0);

--- a/test_pool/da/da_outgoing_realm_rqst_ide_tbit_1.c
+++ b/test_pool/da/da_outgoing_realm_rqst_ide_tbit_1.c
@@ -57,6 +57,12 @@ payload(void)
   tbl_index = 0;
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  if ((bdf_tbl_ptr == NULL) || (bdf_tbl_ptr->num_entries == 0))
+  {
+      val_print(ACS_PRINT_WARN, " No PCIe BDF entries discovered", 0);
+      val_set_status(pe_index, "SKIP", 01);
+      return;
+  }
 
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {

--- a/test_pool/da/da_outgoing_request_with_ide_tbit.c
+++ b/test_pool/da/da_outgoing_request_with_ide_tbit.c
@@ -49,6 +49,12 @@ payload(void)
   tbl_index = 0;
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  if ((bdf_tbl_ptr == NULL) || (bdf_tbl_ptr->num_entries == 0))
+  {
+      val_print(ACS_PRINT_WARN, " No PCIe BDF entries discovered", 0);
+      val_set_status(pe_index, "SKIP", 01);
+      return;
+  }
 
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {

--- a/test_pool/da/da_p2p_btw_2_tdisp_devices.c
+++ b/test_pool/da/da_p2p_btw_2_tdisp_devices.c
@@ -138,6 +138,12 @@ payload(void)
   test_fails = 0;
   index = val_pe_get_index_mpid(val_pe_get_mpid());
   instance = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  if (instance == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+    val_set_status(index, "SKIP", 01);
+    return;
+  }
 
   while (instance-- != 0)
   {

--- a/test_pool/da/da_rmsd_write_detect_property.c
+++ b/test_pool/da/da_rmsd_write_detect_property.c
@@ -58,6 +58,12 @@ payload(void)
   tbl_index = 0;
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  if ((bdf_tbl_ptr == NULL) || (bdf_tbl_ptr->num_entries == 0))
+  {
+      val_print(ACS_PRINT_WARN, " No PCIe BDF entries discovered", 0);
+      val_set_status(pe_index, "SKIP", 01);
+      return;
+  }
 
   table_entries = sizeof(bf_info_table18)/sizeof(bf_info_table18[0]);
   rp_bdf = 0;

--- a/test_pool/da/da_rootport_ide_features.c
+++ b/test_pool/da/da_rootport_ide_features.c
@@ -54,6 +54,13 @@ payload(void)
   tbl_index = 0;
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  if ((bdf_tbl_ptr == NULL) || (bdf_tbl_ptr->num_entries == 0))
+  {
+      val_print(ACS_PRINT_WARN, " No PCIe BDF entries discovered", 0);
+      val_set_status(pe_index, "SKIP", 01);
+      return;
+  }
+
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {
       bdf = bdf_tbl_ptr->device[tbl_index++].bdf;

--- a/test_pool/da/da_rootport_tdisp_disabled.c
+++ b/test_pool/da/da_rootport_tdisp_disabled.c
@@ -65,6 +65,12 @@ payload(void)
   dma_len = test_data_blk_size / 2;
 
   num_exercisers = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  if (num_exercisers == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+    val_set_status(pe_index, "SKIP", 01);
+    return;
+  }
 
   for (instance = 0; instance < num_exercisers; ++instance)
   {
@@ -85,18 +91,21 @@ payload(void)
       val_memory_set(dram_buf_in_virt, dma_len, TEST_DATA);
 
       if (val_pcie_get_rootport(e_bdf, &rp_bdf))
+      {
+          val_memory_free_pages(dram_buf_in_virt, TEST_DATA_NUM_PAGES);
           continue;
-
-      test_skip = 0;
+      }
 
       /* Check for DA Capability */
       if (val_pcie_find_da_capability(rp_bdf, &da_cap_base) != PCIE_SUCCESS)
       {
-          val_print(ACS_PRINT_ERR,
+          val_print(ACS_PRINT_WARN,
                         " PCIe DA DVSEC capability not present,bdf 0x%x", e_bdf);
-          test_fail++;
+          val_memory_free_pages(dram_buf_in_virt, TEST_DATA_NUM_PAGES);
           continue;
       }
+
+      test_skip = 0;
 
       /* Disable RMEDA_CTL1.TDISP_EN*/
       if (val_pcie_disable_tdisp(rp_bdf))
@@ -144,19 +153,25 @@ cleanup_unlock:
 
   tbl_index = 0;
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  if ((bdf_tbl_ptr == NULL) || (bdf_tbl_ptr->num_entries == 0))
+  {
+      val_print(ACS_PRINT_WARN, " No PCIe BDF entries discovered", 0);
+      val_set_status(pe_index, "SKIP", 01);
+      return;
+  }
+
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {
       rp_bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
       dp_type = val_pcie_device_port_type(rp_bdf);
 
-      test_skip = 0;
       if (dp_type == RP)
       {
           /* Check for DA Capability */
           if (val_pcie_find_da_capability(rp_bdf, &da_cap_base) != PCIE_SUCCESS)
           {
-              val_print(ACS_PRINT_ERR,
-                        " PCIe DA DVSEC capability not present,bdf 0x%x", e_bdf);
+              val_print(ACS_PRINT_WARN,
+                        " PCIe DA DVSEC capability not present,bdf 0x%x", rp_bdf);
               continue;
           }
 
@@ -178,6 +193,8 @@ cleanup_unlock:
 
           if (!Bar_Base)
               goto cleanup_unlock_rp;
+
+          test_skip = 0;
 
           va = val_get_free_va(val_get_min_tg());
           pgt_attr_el3 = LOWER_ATTRS(PGT_ENTRY_ACCESS | SHAREABLE_ATTR(OUTER_SHAREABLE)

--- a/test_pool/da/da_selective_ide_register_property.c
+++ b/test_pool/da/da_selective_ide_register_property.c
@@ -76,6 +76,12 @@ payload(void)
   tbl_index = 0;
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  if ((bdf_tbl_ptr == NULL) || (bdf_tbl_ptr->num_entries == 0))
+  {
+      val_print(ACS_PRINT_WARN, " No PCIe BDF entries discovered", 0);
+      val_set_status(pe_index, "SKIP", 01);
+      return;
+  }
 
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {

--- a/test_pool/da/da_tee_io_capability.c
+++ b/test_pool/da/da_tee_io_capability.c
@@ -48,6 +48,13 @@ payload(void)
   tbl_index = 0;
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  if ((bdf_tbl_ptr == NULL) || (bdf_tbl_ptr->num_entries == 0))
+  {
+      val_print(ACS_PRINT_WARN, " No PCIe BDF entries discovered", 0);
+      val_set_status(pe_index, "SKIP", 01);
+      return;
+  }
+
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {
       bdf = bdf_tbl_ptr->device[tbl_index++].bdf;

--- a/test_pool/dpt/dpt_p2p_different_rootport_invalid.c
+++ b/test_pool/dpt/dpt_p2p_different_rootport_invalid.c
@@ -143,6 +143,12 @@ payload(void)
   dma_len = test_data_blk_size / 2;
 
   num_exercisers = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  if (num_exercisers == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+    val_set_status(pe_index, "SKIP", 01);
+    return;
+  }
 
   /* Initialize DMA master and memory descriptors */
   val_memory_set(&master, sizeof(master), 0);

--- a/test_pool/dpt/dpt_p2p_different_rootport_valid.c
+++ b/test_pool/dpt/dpt_p2p_different_rootport_valid.c
@@ -142,6 +142,12 @@ payload(void)
   dma_len = test_data_blk_size / 2;
 
   num_exercisers = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  if (num_exercisers == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+    val_set_status(pe_index, "SKIP", 01);
+    return;
+  }
 
   /* Initialize DMA master and memory descriptors */
   val_memory_set(&master, sizeof(master), 0);

--- a/test_pool/dpt/dpt_p2p_same_rootport_invalid.c
+++ b/test_pool/dpt/dpt_p2p_same_rootport_invalid.c
@@ -143,6 +143,12 @@ payload(void)
   dma_len = test_data_blk_size / 2;
 
   num_exercisers = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  if (num_exercisers == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+    val_set_status(pe_index, "SKIP", 01);
+    return;
+  }
 
   /* Initialize DMA master and memory descriptors */
   val_memory_set(&master, sizeof(master), 0);

--- a/test_pool/dpt/dpt_p2p_same_rootport_valid.c
+++ b/test_pool/dpt/dpt_p2p_same_rootport_valid.c
@@ -142,6 +142,12 @@ payload(void)
   dma_len = test_data_blk_size / 2;
 
   num_exercisers = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  if (num_exercisers == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+    val_set_status(pe_index, "SKIP", 01);
+    return;
+  }
 
   /* Initialize DMA master and memory descriptors */
   val_memory_set(&master, sizeof(master), 0);

--- a/test_pool/dpt/dpt_system_resource_invalid.c
+++ b/test_pool/dpt/dpt_system_resource_invalid.c
@@ -64,6 +64,12 @@ payload(void)
   dma_len = test_data_blk_size / 2;
 
   num_exercisers = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  if (num_exercisers == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+    val_set_status(pe_index, "SKIP", 01);
+    return;
+  }
 
   /* Initialize DMA master and memory descriptors */
   val_memory_set(&master, sizeof(master), 0);
@@ -111,20 +117,20 @@ payload(void)
       if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_ATS, &cap_base) != PCIE_SUCCESS)
             continue;
 
+      /* Check for DA Capability */
+      if (val_pcie_find_da_capability(rp_bdf, &da_cap_base) != PCIE_SUCCESS)
+      {
+          val_print(ACS_PRINT_WARN,
+                        " PCIe DA DVSEC capability not present,bdf 0x%x", bdf);
+          continue;
+      }
+
+      test_skip = 0;
+
       val_print(ACS_PRINT_DEBUG, " Enabling the ATS Cache for the exerciser: 0x%x", bdf);
       val_pcie_read_cfg(bdf, cap_base + ATS_CTRL, &reg_value);
       reg_value |= ATS_CACHING_EN;
       val_pcie_write_cfg(bdf, cap_base + ATS_CTRL, reg_value);
-
-      test_skip = 0;
-
-      /* Check for DA Capability */
-      if (val_pcie_find_da_capability(rp_bdf, &da_cap_base) != PCIE_SUCCESS)
-      {
-          val_print(ACS_PRINT_ERR,
-                        " PCIe DA DVSEC capability not present,bdf 0x%x", bdf);
-          continue;
-      }
 
       /* Enable RMEDA_CTL1.TDISP_EN*/
       if (val_pcie_enable_tdisp(rp_bdf))

--- a/test_pool/dpt/dpt_system_resource_valid_with_dpti.c
+++ b/test_pool/dpt/dpt_system_resource_valid_with_dpti.c
@@ -64,6 +64,12 @@ payload(void)
   dma_len = test_data_blk_size / 2;
 
   num_exercisers = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  if (num_exercisers == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+    val_set_status(pe_index, "SKIP", 01);
+    return;
+  }
 
   /* Initialize DMA master and memory descriptors */
   val_memory_set(&master, sizeof(master), 0);
@@ -107,20 +113,19 @@ payload(void)
       if (val_pcie_get_rootport(bdf, &rp_bdf))
           continue;
 
-      test_skip = 0;
-
       /* Check for DA Capability */
       if (val_pcie_find_da_capability(rp_bdf, &da_cap_base) != PCIE_SUCCESS)
       {
-          val_print(ACS_PRINT_ERR,
+          val_print(ACS_PRINT_WARN,
                         " PCIe DA DVSEC capability not present,bdf 0x%x", bdf);
-          test_fail++;
           continue;
       }
 
       /* If ATS Capability Not Present, Skip. */
       if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_ATS, &cap_base) != PCIE_SUCCESS)
             continue;
+
+      test_skip = 0;
 
       val_print(ACS_PRINT_DEBUG, " Enabling the ATS Cache for the exerciser: 0x%x", bdf);
       val_pcie_read_cfg(bdf, cap_base + ATS_CTRL, &reg_value);

--- a/test_pool/dpt/dpt_system_resource_valid_without_dpti.c
+++ b/test_pool/dpt/dpt_system_resource_valid_without_dpti.c
@@ -64,6 +64,12 @@ payload(void)
   dma_len = test_data_blk_size / 2;
 
   num_exercisers = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  if (num_exercisers == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+    val_set_status(pe_index, "SKIP", 01);
+    return;
+  }
 
   /* Initialize DMA master and memory descriptors */
   val_memory_set(&master, sizeof(master), 0);
@@ -107,20 +113,19 @@ payload(void)
       if (val_pcie_get_rootport(bdf, &rp_bdf))
           continue;
 
-      test_skip = 0;
-
       /* Check for DA Capability */
       if (val_pcie_find_da_capability(rp_bdf, &da_cap_base) != PCIE_SUCCESS)
       {
-          val_print(ACS_PRINT_ERR,
+          val_print(ACS_PRINT_WARN,
                         " PCIe DA DVSEC capability not present,bdf 0x%x", bdf);
-          test_fail++;
           continue;
       }
 
       /* If ATS Capability Not Present, Skip. */
       if (val_pcie_find_capability(bdf, PCIE_ECAP, ECID_ATS, &cap_base) != PCIE_SUCCESS)
             continue;
+
+      test_skip = 0;
 
       val_print(ACS_PRINT_DEBUG, " Enabling the ATS Cache for the exerciser: 0x%x", bdf);
       val_pcie_read_cfg(bdf, cap_base + ATS_CTRL, &reg_value);

--- a/test_pool/gic/gic_its_subjected_to_gpc_check.c
+++ b/test_pool/gic/gic_its_subjected_to_gpc_check.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2024, 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2024, 2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -79,6 +79,7 @@ payload(void)
     uint32_t timeout;
     uint32_t status;
     uint32_t instance;
+    uint32_t num_exercisers;
     uint32_t test_skip = 1;
     uint32_t msi_index = 0;
     uint32_t msi_cap_offset = 0;
@@ -88,35 +89,57 @@ payload(void)
     uint32_t its_id = 0;
     uint64_t its_base = 0, itt_base;
 
-    /* Create the list of valid Pcie Device Functions */
-    if (val_pcie_create_device_bdf_table()) {
-        val_print(ACS_PRINT_WARN, " Create BDF Table Failed...", 0);
-        return;
-    }
-
-    if (val_gic_get_info(GIC_INFO_NUM_ITS) == 0) {
-        val_print(ACS_PRINT_ERR, " No ITS, Skipping Test.", 0);
+    if (val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0) == 0) {
+        val_print(ACS_PRINT_WARN, " No PCIe ECAM regions discovered", 0);
         val_set_status(index, "SKIP", 1);
         return;
     }
 
-    val_exerciser_create_info_table();
-
-    instance = 0;
-
-    if (val_exerciser_init(instance))
-        return;
-
-    /* Get the exerciser BDF */
-    e_bdf = val_exerciser_get_bdf(instance);
-
-    /* Search for MSI-X Capability */
-    if (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) {
-        val_print(ACS_PRINT_ERR, " No MSI-X Capability, Skipping for 0x%x", e_bdf);
+    /* Create the list of valid Pcie Device Functions */
+    if (val_pcie_create_device_bdf_table()) {
+        val_print(ACS_PRINT_WARN, " Create BDF Table Failed...", 0);
+        val_set_status(index, "SKIP", 2);
         return;
     }
 
-    test_skip = 0;
+    if (val_gic_get_info(GIC_INFO_NUM_ITS) == 0) {
+        val_print(ACS_PRINT_WARN, " No ITS, Skipping Test.", 0);
+        val_set_status(index, "SKIP", 3);
+        return;
+    }
+
+    val_exerciser_create_info_table();
+    num_exercisers = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+    if (num_exercisers == 0) {
+        val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+        val_set_status(index, "SKIP", 4);
+        return;
+    }
+
+    for (instance = 0; instance < num_exercisers; ++instance) {
+        if (val_exerciser_init(instance)) {
+            val_print(ACS_PRINT_WARN, " Exerciser init failed for instance %d", instance);
+            continue;
+        }
+
+        /* Get the exerciser BDF */
+        e_bdf = val_exerciser_get_bdf(instance);
+
+        /* Search for MSI-X Capability */
+        if (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_MSIX, &msi_cap_offset)) {
+            val_print(ACS_PRINT_WARN, " No MSI-X Capability for BDF 0x%x", e_bdf);
+            continue;
+        }
+
+        test_skip = 0;
+        break;
+    }
+
+    if (test_skip) {
+        val_print(ACS_PRINT_WARN, " No usable exerciser with MSI-X capability found", 0);
+        val_set_status(index, "SKIP", 5);
+        return;
+    }
 
     /* Get DeviceID & ITS_ID for this device */
     status = val_iovirt_get_device_info(PCIE_CREATE_BDF_PACKED(e_bdf),

--- a/test_pool/mec/mec_mecid_assosiation_and_encryption.c
+++ b/test_pool/mec/mec_mecid_assosiation_and_encryption.c
@@ -47,7 +47,7 @@ payload(void)
 {
 
   uint32_t pe_index;
-  uint32_t instance, num_exercisers;
+  uint32_t instance, num_exercisers, num_smmu;
   uint32_t bdf, rp_bdf, da_cap_base;
   uint32_t dma_len, test_data_blk_size;
   uint32_t status, reg_value;
@@ -72,7 +72,28 @@ payload(void)
   test_data_blk_size = page_size * TEST_DATA_NUM_PAGES;
   dma_len = test_data_blk_size / 2;
 
+  if (val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0) == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No PCIe ECAM regions discovered", 0);
+    val_set_status(pe_index, "SKIP", 01);
+    return;
+  }
+
   num_exercisers = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  if (num_exercisers == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+    val_set_status(pe_index, "SKIP", 02);
+    return;
+  }
+
+  num_smmu = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
+  if (num_smmu == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No SMMU controllers discovered", 0);
+    val_set_status(pe_index, "SKIP", 03);
+    return;
+  }
 
   if (val_rlm_enable_mec())
   {
@@ -144,16 +165,15 @@ payload(void)
       if (val_pcie_get_rootport(bdf, &rp_bdf))
           continue;
 
-      test_skip = 0;
-
       /* Check for DA Capability */
       if (val_pcie_find_da_capability(rp_bdf, &da_cap_base) != PCIE_SUCCESS)
       {
-          val_print(ACS_PRINT_ERR,
+          val_print(ACS_PRINT_WARN,
                         " PCIe DA DVSEC capability not present,bdf 0x%x", bdf);
-          test_fail++;
           continue;
       }
+
+      test_skip = 0;
 
       /* Enable RMEDA_CTL1.TDISP_EN*/
       if (val_pcie_enable_tdisp(rp_bdf))

--- a/test_pool/mec/mec_support_mecid_and_mecid_width.c
+++ b/test_pool/mec/mec_support_mecid_and_mecid_width.c
@@ -64,6 +64,13 @@ payload2(void)
   uint32_t i, common_mecidw = INVALID_MECIDW, max_mecid;
   uint32_t test_fail = 0;
 
+  num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
+  if (num_smmu == 0) {
+      val_print(ACS_PRINT_WARN, " No SMMU controllers discovered", 0);
+      val_set_status(pe_index, "SKIP", 02);
+      return;
+  }
+
   if (val_rlm_enable_mec())
   {
     val_print(ACS_PRINT_ERR, "\n    Failed to enable MEC", 0);
@@ -71,14 +78,7 @@ payload2(void)
     return;
   }
 
-  num_smmu = val_smmu_get_info(SMMU_NUM_CTRL, 0);
-
   smmu_mecidw = val_memory_alloc(num_smmu * sizeof(uint32_t));
-  if (num_smmu == 0) {
-      val_print(ACS_PRINT_ERR, "No SMMU Controllers are discovered ", 0);
-      val_set_status(pe_index, "FAIL", 02);
-      return;
-  }
 
   for (i = 0; i < num_smmu; i++) {
     smmu_base = val_smmu_get_info(SMMU_CTRL_BASE, i);

--- a/test_pool/rme/rme_gpc_for_system_resource.c
+++ b/test_pool/rme/rme_gpc_for_system_resource.c
@@ -48,6 +48,11 @@ void payload(void)
 
   mem_region_cfg = val_mem_gpc_info_table();
   num_regn = mem_region_cfg->header.num_of_regn_gpc;
+  if (num_regn == 0) {
+    val_print(ACS_PRINT_WARN, " No GPC protected regions provided by the platform", 0);
+    val_set_status(index, "SKIP", 01);
+    return;
+  }
   VA = val_get_free_va(num_regn * NUM_PAS * size);
   attr = LOWER_ATTRS(PGT_ENTRY_ACCESS | SHAREABLE_ATTR(NON_SHAREABLE) | PGT_ENTRY_AP_RW);
 

--- a/test_pool/rme/rme_gprs_scrubbed_after_reset.c
+++ b/test_pool/rme/rme_gprs_scrubbed_after_reset.c
@@ -58,6 +58,10 @@ void payload(void)
   val_save_global_test_data();
   write_gpr_and_reset();
 
+  val_print(ACS_PRINT_ERR, " System reset returned unexpectedly", 0);
+  val_set_status(index, "FAIL", 02);
+  return;
+
 reset_done:
   //Check the status of the GPR comparision which is already completed right after the reset
   val_restore_global_test_data();

--- a/test_pool/rme/rme_msd_smem_in_root_after_reset.c
+++ b/test_pool/rme/rme_msd_smem_in_root_after_reset.c
@@ -41,6 +41,12 @@
 static
 void payload(void)
 {
+  uint8_t status_fail_cnt = 0;
+  uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid()), security_state, attr;
+  uint64_t pas_list[4] = {ROOT_PAS, REALM_PAS, NONSECURE_PAS, SECURE_PAS};
+  uint64_t VA, PA, VA_Top, size, rd_data1, rd_data2;
+  uint64_t root_smem_avaialbile = val_get_root_smem_base();
+
   if (val_read_reset_status() == RESET_TST32_FLAG)
           goto reset_done;
 
@@ -49,14 +55,13 @@ void payload(void)
   val_save_global_test_data();
   val_system_reset();
 
+  val_print(ACS_PRINT_ERR, " System reset returned unexpectedly", 0);
+  val_set_status(index, "FAIL", 02);
+  return;
+
 reset_done:
   val_restore_global_test_data();
   val_print(ACS_PRINT_TEST, " After system reset", 0);
-  uint8_t status_fail_cnt = 0;
-  uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid()), security_state, attr;
-  uint64_t pas_list[4] = {ROOT_PAS, REALM_PAS, NONSECURE_PAS, SECURE_PAS};
-  uint64_t VA, PA, VA_Top, size, rd_data1, rd_data2;
-  uint64_t root_smem_avaialbile = val_get_root_smem_base();
 
   shared_data->shared_data_access[0].data = INIT_DATA;
   size = val_get_min_tg();
@@ -66,7 +71,7 @@ reset_done:
   else {
     PA = val_get_free_pa(size, size);
     /* Map this PA as Root in the GPT */
-   val_add_gpt_entry_el3(PA, GPT_ROOT);
+    val_add_gpt_entry_el3(PA, GPT_ROOT);
   }
 
   VA = val_get_free_va(NUM_PAS * NUM_SMEM_REGN * size);

--- a/test_pool/rme/rme_pas_filter_functionality.c
+++ b/test_pool/rme/rme_pas_filter_functionality.c
@@ -50,6 +50,11 @@ void payload(void)
 
   mem_region_pas_filter_cfg = val_mem_pas_info_table();
   num_regn = mem_region_pas_filter_cfg->header.num_of_regn_pas_filter;
+  if (num_regn == 0) {
+    val_print(ACS_PRINT_WARN, " No PAS filter regions provided by the platform", 0);
+    val_set_status(index, "SKIP", 01);
+    return;
+  }
   shared_data->shared_data_access[0].data = INIT_DATA;
   size = val_get_min_tg();
   VA = val_get_free_va(num_regn * NUM_PAS * size);

--- a/test_pool/rme/rme_pas_filter_in_inactive_mode.c
+++ b/test_pool/rme/rme_pas_filter_in_inactive_mode.c
@@ -47,7 +47,12 @@ void payload(void)
   MEM_REGN_INFO_TABLE *mem_region_pas_filter_cfg;
 
   mem_region_pas_filter_cfg = val_mem_pas_info_table();
-  num_regn = mem_region_pas_filter_cfg->header.num_of_regn_gpc;
+  num_regn = mem_region_pas_filter_cfg->header.num_of_regn_pas_filter;
+  if (num_regn == 0) {
+    val_print(ACS_PRINT_WARN, " No PAS filter regions provided by the platform", 0);
+    val_set_status(index, "SKIP", 01);
+    return;
+  }
 
   if (!val_is_pas_filter_mode_programmable()) {
     val_print(ACS_PRINT_ERR, " The pas filter mode is not programmable in this system", 0);

--- a/test_pool/rme/rme_pcie_devices_support_gpc.c
+++ b/test_pool/rme/rme_pcie_devices_support_gpc.c
@@ -168,6 +168,7 @@ payload (void)
     uint32_t pe_index;
     uint32_t instance = 0;
     uint32_t e_bdf = 0, num_smmu;
+    uint32_t smmu_instance;
     void *dram_buf1_virt;
     void *dram_buf1_phys;
     uint32_t cap_base = 0;
@@ -177,6 +178,8 @@ payload (void)
     uint32_t size;
     uint32_t smmu_mapped = 0;
     uint32_t exerciser_ready = 0;
+    uint32_t exerciser_found = 0;
+    uint32_t num_exercisers;
     smmu_master_attributes_t master;
     memory_region_descriptor_t mem_desc_array[2], *mem_desc;
     pgt_descriptor_t cpu_pgt_desc;
@@ -195,7 +198,52 @@ payload (void)
 
     attr = LOWER_ATTRS(PGT_ENTRY_ACCESS | SHAREABLE_ATTR(NON_SHAREABLE) | PGT_ENTRY_AP_RW);
 
+    if (val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0) == 0) {
+        val_print(ACS_PRINT_WARN, " No PCIe ECAM regions discovered", 0);
+        val_set_status(pe_index, "SKIP", 01);
+        return;
+    }
+
+    num_exercisers = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+    if (num_exercisers == 0) {
+        val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+        val_set_status(pe_index, "SKIP", 02);
+        return;
+    }
+
     num_smmu = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
+    if (num_smmu == 0) {
+        val_print(ACS_PRINT_WARN, " No SMMU controllers discovered", 0);
+        val_set_status(pe_index, "SKIP", 03);
+        return;
+    }
+
+    for (instance = 0; instance < num_exercisers; ++instance) {
+        if (val_exerciser_init(instance)) {
+            val_print(ACS_PRINT_WARN, " Exerciser init failed for instance %d", instance);
+            continue;
+        }
+
+        e_bdf = val_exerciser_get_bdf(instance);
+        if (val_pcie_find_capability(e_bdf, PCIE_ECAP, ECID_ATS, &cap_base) != PCIE_SUCCESS) {
+            val_print(ACS_PRINT_WARN, " ATS capability not found for BDF 0x%x", e_bdf);
+            continue;
+        }
+
+        exerciser_found = 1;
+        exerciser_ready = 1;
+        break;
+    }
+
+    if (!exerciser_found) {
+        val_print(ACS_PRINT_WARN, " No usable exerciser with ATS capability found", 0);
+        val_set_status(pe_index, "SKIP", 04);
+        return;
+    }
+
+    /* Disable All SMMU's */
+    for (smmu_instance = 0; smmu_instance < num_smmu; ++smmu_instance)
+        val_smmu_disable(smmu_instance);
 
     /* Get translation attributes via TCR and translation table base via TTBR */
     if (val_pe_reg_read_tcr(0 /*for TTBR0*/,
@@ -213,19 +261,6 @@ payload (void)
     /* Initialize DMA master and memory descriptors */
     val_memory_set(mem_desc_array, sizeof(mem_desc_array), 0);
     mem_desc = &mem_desc_array[0];
-
-    /* Disable All SMMU's */
-    for (instance = 0; instance < num_smmu; ++instance)
-        val_smmu_disable(instance);
-
-    instance = 0;
-    /* Initialise the exerciser */
-    if (val_exerciser_init(instance))
-        goto test_fail;
-    exerciser_ready = 1;
-
-    /* Get the exerciser BDF */
-    e_bdf = val_exerciser_get_bdf(instance);
 
     /* Find SMMU node index for this exerciser instance */
     master.smmu_index = val_iovirt_get_rc_smmu_index(PCIE_EXTRACT_BDF_SEG(e_bdf),
@@ -249,10 +284,7 @@ payload (void)
     attr = LOWER_ATTRS(PGT_ENTRY_ACCESS | SHAREABLE_ATTR(NON_SHAREABLE) | PGT_ENTRY_AP_RW);
 
 
-    /* If ATS Capability Not Present, Skip. */
-    if (val_pcie_find_capability(e_bdf, PCIE_ECAP, ECID_ATS, &cap_base) != PCIE_SUCCESS)
-       goto test_fail;
-
+    /* ATS capability was verified while selecting the exerciser. */
     val_pcie_read_cfg(e_bdf, cap_base + ATS_CTRL, &reg_value);
     reg_value |= ATS_CACHING_EN;
     val_pcie_write_cfg(e_bdf, cap_base + ATS_CTRL, reg_value);
@@ -291,7 +323,7 @@ payload (void)
             goto test_fail;
 
       /* We create the requisite page tables and configure the SMMU for exerciser*/
-      mem_desc->virtual_address = (uint64_t)dram_buf1_virt + instance * test_data_blk_size;
+      mem_desc->virtual_address = (uint64_t)dram_buf1_virt;
       mem_desc->physical_address = (uint64_t)dram_buf1_phys;
       mem_desc->length = test_data_blk_size;
       mem_desc->attributes |= (PGT_STAGE1_AP_RW);
@@ -389,8 +421,8 @@ test_clean:
   }
 
   /* Disable all SMMUs */
-  for (instance = 0; instance < num_smmu; ++instance)
-     val_smmu_disable(instance);
+  for (smmu_instance = 0; smmu_instance < num_smmu; ++smmu_instance)
+     val_smmu_disable(smmu_instance);
 
 }
 

--- a/test_pool/rme/rme_realm_smem_behaviour_after_reset.c
+++ b/test_pool/rme/rme_realm_smem_behaviour_after_reset.c
@@ -86,6 +86,10 @@ void payload(void)
   val_save_global_test_data();
   val_system_reset();
 
+  val_print(ACS_PRINT_ERR, " System reset returned unexpectedly", 0);
+  val_set_status(index, "FAIL", 02);
+  return;
+
 reset_done:
   val_print(ACS_PRINT_TEST, " After system reset", 0);
   val_restore_global_test_data();

--- a/test_pool/rme/rme_resources_aligned_to_granularity.c
+++ b/test_pool/rme/rme_resources_aligned_to_granularity.c
@@ -45,6 +45,11 @@ void payload(void)
   mem_region_cfg = val_mem_gpc_info_table();
   num_regn = mem_region_cfg->header.num_of_regn_gpc;
   status_fail_cnt = 0;
+  if (num_regn == 0) {
+    val_print(ACS_PRINT_WARN, " No GPC protected regions provided by the platform", 0);
+    val_set_status(index, "SKIP", 01);
+    return;
+  }
 
   for (uint32_t regn_cnt = 0; regn_cnt < num_regn; ++regn_cnt)
   {

--- a/test_pool/rme/rme_resources_are_not_physically_aliased.c
+++ b/test_pool/rme/rme_resources_are_not_physically_aliased.c
@@ -44,6 +44,11 @@ void payload(void)
   mem_region_cfg = val_mem_gpc_info_table();
   num_regn = mem_region_cfg->header.num_of_regn_gpc;
   status_fail_cnt = 0;
+  if (num_regn == 0) {
+    val_print(ACS_PRINT_WARN, " No GPC protected regions provided by the platform", 0);
+    val_set_status(index, "SKIP", 01);
+    return;
+  }
 
   for (uint32_t regn_cnt = 0; regn_cnt < num_regn; ++regn_cnt) {
 

--- a/test_pool/rme/rme_smmu_blocks_request_at_registers_reset.c
+++ b/test_pool/rme/rme_smmu_blocks_request_at_registers_reset.c
@@ -83,24 +83,45 @@ payload(void)
   uint32_t instance;
   uint32_t e_bdf, num_smmu;
   uint32_t smmu_index;
+  uint32_t num_exercisers;
+  uint32_t test_skip;
   uint64_t smmu_base;
   void *dram_buf1_virt;
   void *dram_buf1_phys;
 
   dram_buf1_virt = NULL;
   dram_buf1_phys = NULL;
+  smmu_base = 0;
+  test_skip = 1;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   num_smmu = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
+  if (num_smmu == 0) {
+      val_print(ACS_PRINT_WARN, " No SMMU controllers discovered", 0);
+      val_set_status(pe_index, "SKIP", 01);
+      return;
+  }
+
+  if (val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0) == 0) {
+      val_print(ACS_PRINT_WARN, " No PCIe ECAM regions discovered", 0);
+      val_set_status(pe_index, "SKIP", 02);
+      return;
+  }
+
+  /* Read the number of excerciser cards */
+  num_exercisers = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  if (num_exercisers == 0) {
+      val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+      val_set_status(pe_index, "SKIP", 03);
+      return;
+  }
 
   /* Disable All SMMU's */
   for (instance = 0; instance < num_smmu; ++instance)
       val_smmu_disable(instance);
 
-  /* Read the number of excerciser cards */
-  instance = val_exerciser_get_info(EXERCISER_NUM_CARDS);
-
+  instance = num_exercisers;
   while (instance-- != 0) {
 
     /* if init fail moves to next exerciser */
@@ -114,26 +135,30 @@ payload(void)
     smmu_index = val_iovirt_get_rc_smmu_index(PCIE_EXTRACT_BDF_SEG(e_bdf),
                     PCIE_CREATE_BDF_PACKED(e_bdf));
 
+    if (smmu_index == ACS_INVALID_INDEX) {
+        val_print(ACS_PRINT_WARN, " No SMMU mapping found for exerciser %x", instance);
+        continue;
+    }
+
+    test_skip = 0;
     smmu_base = val_smmu_get_info(SMMU_CTRL_BASE, smmu_index);
     /* Disable SMMU globally by writing reset values to SMMU_CR0.SMMUEN and
      * SMMU_ROOT_CR0.ACCESSEN thereby setting the SMMU in reset state.
      */
     val_print(ACS_PRINT_TEST,
       " Disabling SMMU %d through it's Control registers in both Root and NS state", smmu_index);
-    if (smmu_index != ACS_INVALID_INDEX) {
-        if (val_smmu_access_disable(smmu_base))
-        {
-            val_print(ACS_PRINT_ERR, " Exerciser %x smmu root access disable error", instance);
-            val_smmu_access_enable(smmu_base);
-            val_set_status(pe_index, "FAIL", 01);
-            return;
-        }
-        if (val_smmu_disable(smmu_index)) {
-            val_print(ACS_PRINT_ERR, " Exerciser %x smmu disable error", instance);
-            val_smmu_access_enable(smmu_base);
-            val_set_status(pe_index, "FAIL", 02);
-            return;
-        }
+    if (val_smmu_access_disable(smmu_base))
+    {
+        val_print(ACS_PRINT_ERR, " Exerciser %x smmu root access disable error", instance);
+        val_smmu_access_enable(smmu_base);
+        val_set_status(pe_index, "FAIL", 01);
+        return;
+    }
+    if (val_smmu_disable(smmu_index)) {
+        val_print(ACS_PRINT_ERR, " Exerciser %x smmu disable error", instance);
+        val_smmu_access_enable(smmu_base);
+        val_set_status(pe_index, "FAIL", 02);
+        return;
     }
 
     /* Get a WB, outer shareable DDR Buffer which is Non-Secure of size TEST_DATA_BLK_SIZE */
@@ -152,12 +177,18 @@ payload(void)
 
   }
 
-  val_smmu_access_enable(smmu_base);
-  val_set_status(pe_index, "PASS", 0);
+  if (!test_skip && smmu_base != 0)
+      val_smmu_access_enable(smmu_base);
+
+  if (test_skip)
+      val_set_status(pe_index, "SKIP", 03);
+  else
+      val_set_status(pe_index, "PASS", 0);
   return;
 
 test_fail:
-  val_smmu_access_enable(smmu_base);
+  if (smmu_base != 0)
+      val_smmu_access_enable(smmu_base);
   val_set_status(pe_index, "FAIL", 06);
   val_memory_free_cacheable(e_bdf, TEST_DATA_BLK_SIZE, dram_buf1_virt, dram_buf1_phys);
   return;

--- a/test_pool/rme/rme_system_reset_propagation_to_all_pe.c
+++ b/test_pool/rme/rme_system_reset_propagation_to_all_pe.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023, 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -105,6 +105,10 @@ void payload(uint32_t num_pe)
   val_write_reset_status(RESET_TST31_FLAG);
   val_save_global_test_data();
   write_gpr_and_reset();
+
+  val_print(ACS_PRINT_ERR, " System reset returned unexpectedly", 0);
+  val_set_status(index, "FAIL", 03);
+  return;
 
 reset_done:
   val_restore_global_test_data();

--- a/test_pool/smmu/smmu_responds_to_gpt_tlb.c
+++ b/test_pool/smmu/smmu_responds_to_gpt_tlb.c
@@ -49,21 +49,17 @@
  * 8. Expect unsuccessful access.
  */
 static
-void
-payload(void)
+uint32_t
+run_smmu_gpt_tlb_sequence(uint32_t instance, uint32_t e_bdf, uint32_t smmu_index,
+                          uint32_t cap_base, uint32_t num_smmus)
 {
-  uint32_t pe_index;
   uint32_t dma_len = 0, attr = 0;
-  uint32_t instance = 0;
-  uint32_t e_bdf = 0;
-  uint32_t cap_base = 0;
   void *dram_buf_in_virt = NULL;
   void *dram_buf_out_virt = NULL;
   uint64_t dram_buf_in_phys = 0;
   uint64_t dram_buf_out_phys = 0;
   uint64_t dram_buf_in_iova = 0;
   uint64_t dram_buf_out_iova = 0;
-  uint32_t num_smmus;
   uint32_t device_id, its_id;
   uint32_t page_size = val_memory_page_size();
   memory_region_descriptor_t mem_desc_array[2], *mem_desc;
@@ -71,65 +67,46 @@ payload(void)
   pgt_descriptor_t smmu_pgt_desc;
   smmu_master_attributes_t master;
   uint64_t ttbr = 0;
-  uint32_t test_data_blk_size = page_size * TEST_DATA_NUM_PAGES;
+  uint32_t test_data_blk_size;
   uint32_t reg_value = 0;
   uint64_t size;
-  uint32_t exerciser_ready = 0;
+  uint32_t smmu_instance;
+  uint32_t ats_enabled = 0;
   uint32_t smmu_mapped = 0;
+  uint32_t status = ACS_STATUS_FAIL;
 
-  /* Enable all SMMUs */
-  num_smmus = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
+  if (page_size == 0)
+      return ACS_STATUS_FAIL;
+
+  test_data_blk_size = page_size * TEST_DATA_NUM_PAGES;
 
   /* Initialize DMA master and memory descriptors */
   val_memory_set(&master, sizeof(master), 0);
-  master.smmu_index = ACS_INVALID_INDEX;
+  master.smmu_index = smmu_index;
   val_memory_set(mem_desc_array, sizeof(mem_desc_array), 0);
   val_memory_set(&cpu_pgt_desc, sizeof(cpu_pgt_desc), 0);
   val_memory_set(&smmu_pgt_desc, sizeof(smmu_pgt_desc), 0);
   mem_desc = &mem_desc_array[0];
 
-  pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
-
   /* Get translation attributes via TCR and translation table base via TTBR */
-  if (val_pe_reg_read_tcr(0 /*for TTBR0*/,
-                          &cpu_pgt_desc.tcr)) {
+  if (val_pe_reg_read_tcr(0 /*for TTBR0*/, &cpu_pgt_desc.tcr)) {
     val_print(ACS_PRINT_ERR, " TCR read failure", 0);
-    goto test_fail;
+    goto test_clean;
   }
 
-  if (val_pe_reg_read_ttbr(0 /*for TTBR0*/,
-                           &ttbr)) {
+  if (val_pe_reg_read_ttbr(0 /*for TTBR0*/, &ttbr)) {
     val_print(ACS_PRINT_ERR, " TTBR0 read failure", 0);
-    goto test_fail;
+    goto test_clean;
   }
 
   /* Disable All SMMU's */
-    for (instance = 0; instance < num_smmus; ++instance)
-        val_smmu_disable(instance);
+  for (smmu_instance = 0; smmu_instance < num_smmus; ++smmu_instance)
+      val_smmu_disable(smmu_instance);
 
-  instance = 0;
-  /* if init fail moves to next exerciser */
-  if (val_exerciser_init(instance))
-        goto test_fail;
-  exerciser_ready = 1;
-
-  /* Get exerciser bdf */
-  e_bdf = val_exerciser_get_bdf(instance);
-  val_print(ACS_PRINT_TEST, " Exerciser BDF - 0x%x", e_bdf);
-
-  /* Get SMMU node index for this exerciser instance */
-  master.smmu_index = val_iovirt_get_rc_smmu_index(PCIE_EXTRACT_BDF_SEG(e_bdf),
-                                                   PCIE_CREATE_BDF_PACKED(e_bdf));
-
-  /* Enable SMMU globally so that the transaction passes
-   * through the SMMU.
-   */
-  if (master.smmu_index != ACS_INVALID_INDEX) {
-      if (val_smmu_enable(master.smmu_index)) {
-            val_print(ACS_PRINT_ERR, " Exerciser %x smmu disable error", instance);
-            val_set_status(pe_index, "FAIL", 02);
-            goto test_fail;
-        }
+  /* Enable SMMU globally so that the transaction passes through the SMMU. */
+  if (val_smmu_enable(master.smmu_index)) {
+      val_print(ACS_PRINT_ERR, " Exerciser %x smmu enable error", instance);
+      goto test_clean;
   }
 
   size = val_get_min_tg();
@@ -142,12 +119,10 @@ payload(void)
   dram_buf_out_phys = dram_buf_in_phys + (test_data_blk_size / 2);
   dma_len = test_data_blk_size / 2;
 
-  /* If ATS Capability Not Present, Skip. */
-  if (val_pcie_find_capability(e_bdf, PCIE_ECAP, ECID_ATS, &cap_base) != PCIE_SUCCESS)
-       goto test_fail;
   val_pcie_read_cfg(e_bdf, cap_base + ATS_CTRL, &reg_value);
   reg_value |= ATS_CACHING_EN;
   val_pcie_write_cfg(e_bdf, cap_base + ATS_CTRL, reg_value);
+  ats_enabled = 1;
 
   cpu_pgt_desc.pgt_base = (ttbr & AARCH64_TTBR_ADDR_MASK);
   cpu_pgt_desc.mair = val_pe_reg_read(MAIR_ELx);
@@ -162,91 +137,85 @@ payload(void)
   if (val_pgt_create(mem_desc, &cpu_pgt_desc)) {
         val_print(ACS_PRINT_ERR,
                       " Unable to create page table with given attributes", 0);
-            goto test_fail;
-      }
-
+        goto test_clean;
+  }
 
   /* Get memory attributes of the test buffer, we'll use the same attibutes to create
    * our own page table later.
    */
   if (val_pgt_get_attributes(cpu_pgt_desc, (uint64_t)dram_buf_in_virt, &mem_desc->attributes)) {
         val_print(ACS_PRINT_ERR, " Unable to get memory attributes of the test buffer", 0);
-        goto test_fail;
+        goto test_clean;
   }
 
   dram_buf_in_iova = dram_buf_in_phys;
   dram_buf_out_iova = dram_buf_out_phys;
-  if (master.smmu_index != ACS_INVALID_INDEX &&
-      val_iovirt_get_smmu_info(SMMU_CTRL_ARCH_MAJOR_REV, master.smmu_index) == 3) {
-      if (val_iovirt_get_device_info(PCIE_CREATE_BDF_PACKED(e_bdf),
-                                     PCIE_EXTRACT_BDF_SEG(e_bdf),
-                                     &device_id, &master.streamid,
-                                     &its_id))
-            goto test_fail;
 
-      /* We create the requisite page tables and configure the SMMU for exerciser*/
-      mem_desc->virtual_address = (uint64_t)dram_buf_in_virt;
-      mem_desc->physical_address = dram_buf_in_phys;
-      mem_desc->length = test_data_blk_size;
-      mem_desc->attributes |= (PGT_STAGE1_AP_RW);
+  if (val_iovirt_get_device_info(PCIE_CREATE_BDF_PACKED(e_bdf),
+                                 PCIE_EXTRACT_BDF_SEG(e_bdf),
+                                 &device_id, &master.streamid,
+                                 &its_id))
+        goto test_clean;
 
-      //Map the memory as Non-secure for the instance
-      if (val_add_gpt_entry_el3(mem_desc->physical_address, GPT_NONSECURE))
-      {
-          val_print(ACS_PRINT_ERR, " GPT mapping failed for the address: 0x%llx",
-            mem_desc->physical_address);
-          goto test_fail;
+  /* We create the requisite page tables and configure the SMMU for exerciser */
+  mem_desc->virtual_address = (uint64_t)dram_buf_in_virt;
+  mem_desc->physical_address = dram_buf_in_phys;
+  mem_desc->length = test_data_blk_size;
+  mem_desc->attributes |= (PGT_STAGE1_AP_RW);
 
-      }
-      attr = LOWER_ATTRS(PGT_ENTRY_ACCESS | SHAREABLE_ATTR(OUTER_SHAREABLE) | PGT_ENTRY_AP_RW);
-      if (val_add_mmu_entry_el3(mem_desc->virtual_address, mem_desc->physical_address,
-                      (attr | LOWER_ATTRS(PAS_ATTR(NONSECURE_PAS)))))
-      {
-          val_print(ACS_PRINT_ERR, " Failed to add MMU entry for dram_buf_in_virt: 0x%llx",
-                    (uint64_t)dram_buf_in_virt);
-          goto test_fail;
-      }
-
-      //Clear the memory
-      val_memory_set((uint64_t *)dram_buf_in_virt, dma_len, 0);
-      val_data_cache_ops_by_va((uint64_t)dram_buf_in_virt, CLEAN_AND_INVALIDATE);
-
-      /* Need to know input and output address sizes before creating page table */
-      smmu_pgt_desc = cpu_pgt_desc;
-      smmu_pgt_desc.ias = val_smmu_get_info(SMMU_IN_ADDR_SIZE, master.smmu_index);
-      if ((smmu_pgt_desc.ias) == 0) {
-            val_print(ACS_PRINT_ERR,
-                          " Input address size of SMMU %d is 0", master.smmu_index);
-            goto test_fail;
-      }
-
-      smmu_pgt_desc.oas = val_smmu_get_info(SMMU_OUT_ADDR_SIZE, master.smmu_index);
-      if ((smmu_pgt_desc.oas) == 0) {
-            val_print(ACS_PRINT_ERR,
-                          " Output address size of SMMU %d is 0", master.smmu_index);
-            goto test_fail;
-      }
-
-      /* set pgt_base to NULL to create a new translation table for the SMMU */
-      smmu_pgt_desc.pgt_base = (uint64_t) NULL;
-      if (val_pgt_create(mem_desc, &smmu_pgt_desc)) {
-            val_print(ACS_PRINT_ERR,
-                      " Unable to create page table with given attributes", 0);
-            goto test_fail;
-      }
-
-      /* Configure the SMMU tables for this exerciser to use this page table
-         for VA to PA translations*/
-      if (val_smmu_map(master, smmu_pgt_desc))
-      {
-            val_print(ACS_PRINT_ERR, " SMMU mapping failed (%x)     ", e_bdf);
-            goto test_fail;
-      }
-      smmu_mapped = 1;
-
-      dram_buf_in_iova = mem_desc->virtual_address;
-      dram_buf_out_iova = dram_buf_in_iova + (test_data_blk_size / 2);
+  /* Map the memory as Non-secure for the instance */
+  if (val_add_gpt_entry_el3(mem_desc->physical_address, GPT_NONSECURE))
+  {
+      val_print(ACS_PRINT_ERR, " GPT mapping failed for the address: 0x%llx",
+        mem_desc->physical_address);
+      goto test_clean;
   }
+
+  attr = LOWER_ATTRS(PGT_ENTRY_ACCESS | SHAREABLE_ATTR(OUTER_SHAREABLE) | PGT_ENTRY_AP_RW);
+  if (val_add_mmu_entry_el3(mem_desc->virtual_address, mem_desc->physical_address,
+                  (attr | LOWER_ATTRS(PAS_ATTR(NONSECURE_PAS)))))
+  {
+      val_print(ACS_PRINT_ERR, " Failed to add MMU entry for dram_buf_in_virt: 0x%llx",
+                (uint64_t)dram_buf_in_virt);
+      goto test_clean;
+  }
+
+  /* Clear the memory */
+  val_memory_set((uint64_t *)dram_buf_in_virt, dma_len, 0);
+  val_data_cache_ops_by_va((uint64_t)dram_buf_in_virt, CLEAN_AND_INVALIDATE);
+
+  /* Need to know input and output address sizes before creating page table */
+  smmu_pgt_desc = cpu_pgt_desc;
+  smmu_pgt_desc.ias = val_smmu_get_info(SMMU_IN_ADDR_SIZE, master.smmu_index);
+  if ((smmu_pgt_desc.ias) == 0) {
+        val_print(ACS_PRINT_ERR, " Input address size of SMMU %d is 0", master.smmu_index);
+        goto test_clean;
+  }
+
+  smmu_pgt_desc.oas = val_smmu_get_info(SMMU_OUT_ADDR_SIZE, master.smmu_index);
+  if ((smmu_pgt_desc.oas) == 0) {
+        val_print(ACS_PRINT_ERR, " Output address size of SMMU %d is 0", master.smmu_index);
+        goto test_clean;
+  }
+
+  /* set pgt_base to NULL to create a new translation table for the SMMU */
+  smmu_pgt_desc.pgt_base = (uint64_t) NULL;
+  if (val_pgt_create(mem_desc, &smmu_pgt_desc)) {
+        val_print(ACS_PRINT_ERR, " Unable to create page table with given attributes", 0);
+        goto test_clean;
+  }
+
+  /* Configure the SMMU tables for this exerciser to use this page table
+     for VA to PA translations */
+  if (val_smmu_map(master, smmu_pgt_desc))
+  {
+        val_print(ACS_PRINT_ERR, " SMMU mapping failed (%x)     ", e_bdf);
+        goto test_clean;
+  }
+  smmu_mapped = 1;
+
+  dram_buf_in_iova = mem_desc->virtual_address;
+  dram_buf_out_iova = dram_buf_in_iova + (test_data_blk_size / 2);
 
   /* Initialize the sender buffer with test specific data */
   val_memory_set((uint64_t *)dram_buf_in_virt, dma_len, TEST_DATA);
@@ -257,71 +226,67 @@ payload(void)
 
   if (val_exerciser_set_param(DMA_ATTRIBUTES, dram_buf_in_phys, dma_len, instance)) {
         val_print(ACS_PRINT_ERR, " DMA attributes setting failure %4x", instance);
-        goto test_fail;
+        goto test_clean;
   }
 
   /* Trigger DMA from input buffer to exerciser memory */
   if (val_exerciser_ops(START_DMA, EDMA_TO_DEVICE, instance)) {
         val_print(ACS_PRINT_ERR, " DMA write failure to exerciser %4x", instance);
-        goto test_fail;
+        goto test_clean;
   }
 
   if (val_exerciser_set_param(DMA_ATTRIBUTES, dram_buf_out_iova, dma_len, instance)) {
         val_print(ACS_PRINT_ERR, " DMA attributes setting failure %4x", instance);
-        goto test_fail;
+        goto test_clean;
   }
 
-  /* Trigger DMA from exerciser memory to output buffer*/
+  /* Trigger DMA from exerciser memory to output buffer */
   if (val_exerciser_ops(START_DMA, EDMA_FROM_DEVICE, instance)) {
         val_print(ACS_PRINT_ERR, " DMA read failure from exerciser %4x", instance);
-        goto test_fail;
+        goto test_clean;
   }
 
   if (val_memory_compare(dram_buf_in_virt, dram_buf_out_virt, dma_len)) {
         val_print(ACS_PRINT_ERR, " Data Comparasion failure for Exerciser %4x", instance);
-        goto test_fail;
+        goto test_clean;
   }
   val_print(ACS_PRINT_TEST, " The Nonsecure DMA transaction is successful", 0);
 
-  //clear the memory before the next transaction
+  /* Clear the memory before the next transaction */
   val_memory_set((uint64_t *)dram_buf_in_virt, dma_len, 0);
   val_data_cache_ops_by_va((uint64_t)dram_buf_in_virt, CLEAN_AND_INVALIDATE);
 
-  //Disable smmu now
+  /* Disable smmu now */
   val_print(ACS_PRINT_TEST, " Disabling SMMU of index: %d", master.smmu_index);
   val_smmu_disable(master.smmu_index);
 
   val_exerciser_set_param(DMA_ATTRIBUTES, dram_buf_in_phys, dma_len, instance);
 
-  //Change the GPI for the PA
+  /* Change the GPI for the PA */
   if (val_add_gpt_entry_el3(dram_buf_in_phys, GPT_ROOT))
   {
       val_print(ACS_PRINT_ERR, " GPT mapping failed for 0x%llx", dram_buf_in_phys);
-      goto test_fail;
+      goto test_clean;
   }
 
-  //Enable smmu now
+  /* Enable smmu now */
   val_print(ACS_PRINT_TEST, " Enabling SMMU of index: %d", master.smmu_index);
   val_smmu_enable(master.smmu_index);
 
-  // Trigger DMA from input buffer to exerciser memory
+  /* Trigger DMA from input buffer to exerciser memory */
   if (!(val_exerciser_ops(START_DMA, EDMA_TO_DEVICE, instance))) {
         val_print(ACS_PRINT_ERR, " ERROR:      DMA write success to exerciser %4x", instance);
-        goto test_fail;
+        goto test_clean;
   }
 
-  val_set_status(pe_index, "PASS", 01);
-  goto test_clean;
-
-test_fail:
-  val_set_status(pe_index, "FAIL", 01);
+  status = ACS_STATUS_PASS;
 
 test_clean:
   if ((dram_buf_in_phys != 0u) && val_add_gpt_entry_el3(dram_buf_in_phys, GPT_ANY))
   {
       val_print(ACS_PRINT_ERR,
                   " test_clean: Failed to clear GPT entry for PA 0x%llx", dram_buf_in_phys);
-      val_set_status(pe_index, "FAIL", 02);
+      status = ACS_STATUS_FAIL;
   }
 
   if ((dram_buf_in_virt != NULL) && (dram_buf_in_phys != 0u) &&
@@ -330,22 +295,23 @@ test_clean:
   {
       val_print(ACS_PRINT_ERR,
                   " test_clean: Failed to add MMU entry for PA 0x%llx", dram_buf_in_phys);
-      val_set_status(pe_index, "FAIL", 03);
+      status = ACS_STATUS_FAIL;
   }
 
-  //Clear the memory
+  /* Clear the memory */
   if ((dram_buf_in_virt != NULL) && (dma_len != 0u) &&
       val_memory_set_el3((uint64_t *)dram_buf_in_virt, dma_len/2, 0))
   {
       val_print(ACS_PRINT_ERR, " test_clean: Failed to set memory to 0 ", 0);
-      val_set_status(pe_index, "FAIL", 04);
+      status = ACS_STATUS_FAIL;
   }
-  //Clean and invalidate the memory
+
+  /* Clean and invalidate the memory */
   if ((dram_buf_in_virt != NULL) &&
       val_data_cache_ops_by_va_el3((uint64_t)dram_buf_in_virt, CLEAN_AND_INVALIDATE))
   {
       val_print(ACS_PRINT_ERR, " test_clean: Failed to clean and invalidate dram_buf_in", 0);
-      val_set_status(pe_index, "FAIL", 05);
+      status = ACS_STATUS_FAIL;
   }
 
   if (smmu_mapped)
@@ -354,8 +320,7 @@ test_clean:
   if (smmu_pgt_desc.pgt_base != (uint64_t) NULL)
       val_pgt_destroy(smmu_pgt_desc);
 
-  if (exerciser_ready &&
-      (val_pcie_find_capability(e_bdf, PCIE_ECAP, ECID_ATS, &cap_base) == PCIE_SUCCESS))
+  if (ats_enabled)
   {
         val_pcie_read_cfg(e_bdf, cap_base + ATS_CTRL, &reg_value);
         reg_value &= ATS_CACHING_DIS;
@@ -363,9 +328,91 @@ test_clean:
   }
 
   /* Disable all SMMUs */
-  for (instance = 0; instance < num_smmus; ++instance)
-     val_smmu_disable(instance);
+  for (smmu_instance = 0; smmu_instance < num_smmus; ++smmu_instance)
+     val_smmu_disable(smmu_instance);
 
+  return status;
+}
+
+static
+void
+payload(void)
+{
+  uint32_t pe_index;
+  uint32_t instance;
+  uint32_t e_bdf;
+  uint32_t cap_base;
+  uint32_t smmu_index;
+  uint32_t num_smmus;
+  uint32_t num_exercisers;
+  uint32_t test_run = 0;
+  uint32_t status;
+
+  num_smmus = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
+
+  pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
+  if (num_smmus == 0) {
+    val_print(ACS_PRINT_WARN, " No SMMU controllers discovered", 0);
+    val_set_status(pe_index, "SKIP", 01);
+    return;
+  }
+
+  if (val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0) == 0) {
+    val_print(ACS_PRINT_WARN, " No PCIe ECAM regions discovered", 0);
+    val_set_status(pe_index, "SKIP", 02);
+    return;
+  }
+
+  num_exercisers = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  if (num_exercisers == 0) {
+    val_print(ACS_PRINT_WARN, " No exerciser cards discovered", 0);
+    val_set_status(pe_index, "SKIP", 03);
+    return;
+  }
+
+  for (instance = 0; instance < num_exercisers; ++instance) {
+    if (val_exerciser_init(instance)) {
+      val_print(ACS_PRINT_WARN, " Exerciser init failed for instance %d", instance);
+      continue;
+    }
+
+    e_bdf = val_exerciser_get_bdf(instance);
+    val_print(ACS_PRINT_TEST, " Exerciser BDF - 0x%x", e_bdf);
+
+    smmu_index = val_iovirt_get_rc_smmu_index(PCIE_EXTRACT_BDF_SEG(e_bdf),
+                                              PCIE_CREATE_BDF_PACKED(e_bdf));
+    if (smmu_index == ACS_INVALID_INDEX || smmu_index >= num_smmus) {
+      val_print(ACS_PRINT_WARN, " No SMMU mapping found for exerciser %x", instance);
+      continue;
+    }
+
+    if (val_iovirt_get_smmu_info(SMMU_CTRL_ARCH_MAJOR_REV, smmu_index) != 3) {
+      val_print(ACS_PRINT_WARN, " Test requires SMMUv3 for exerciser %x", instance);
+      continue;
+    }
+
+    if (val_pcie_find_capability(e_bdf, PCIE_ECAP, ECID_ATS, &cap_base) != PCIE_SUCCESS)
+    {
+      val_print(ACS_PRINT_WARN, " ATS capability not found for BDF 0x%x", e_bdf);
+      continue;
+    }
+
+    status = run_smmu_gpt_tlb_sequence(instance, e_bdf, smmu_index, cap_base, num_smmus);
+    if (status == ACS_STATUS_FAIL) {
+      val_set_status(pe_index, "FAIL", 03);
+      return;
+    }
+
+    test_run++;
+  }
+
+  if (test_run == 0) {
+    val_print(ACS_PRINT_WARN, " No usable exerciser backed by SMMUv3 discovered", 0);
+    val_set_status(pe_index, "SKIP", 04);
+    return;
+  }
+
+  val_set_status(pe_index, "PASS", 01);
 }
 
 uint32_t

--- a/val/src/val_cxl.c
+++ b/val/src/val_cxl.c
@@ -710,6 +710,9 @@ uint64_t
 val_cxl_get_component_info(CXL_COMPONENT_INFO_e type, uint32_t index)
 {
   if (g_cxl_component_table == NULL) {
+    if (type == CXL_COMPONENT_INFO_COUNT)
+      return 0;
+
     val_print(ACS_PRINT_ERR, " GET_CXL_COMPONENT_INFO: component table not created", 0);
     return 0;
   }
@@ -3388,6 +3391,12 @@ val_rme_cxl_execute_tests(uint32_t num_pe)
   uint32_t smmu_cnt;
 
   g_curr_module = 1 << CXL_MODULE_ID;
+
+  if (num_smmus == 0)
+  {
+    val_print(ACS_PRINT_WARN, " No SMMU Controller Found, Skipping RME-CXL tests...", 0);
+    return ACS_STATUS_SKIP;
+  }
 
   if (!g_rl_smmu_init)
   {

--- a/val/src/val_mec.c
+++ b/val/src/val_mec.c
@@ -23,6 +23,7 @@
 #include "include/val_mem_interface.h"
 #include "include/val_interface.h"
 #include "include/val_pe.h"
+#include "include/val_memory.h"
 
 /**
   @brief   This API will execute all RME MEC tests designated for a given compliance level
@@ -35,9 +36,11 @@
 uint32_t
 val_rme_mec_execute_tests(uint32_t num_pe)
 {
-  uint32_t status = ACS_STATUS_SKIP, reset_status, smmu_cnt;
+  uint32_t status = ACS_STATUS_SKIP, reset_status, smmu_cnt, page_size;
   uint64_t num_smmus = val_smmu_get_info(SMMU_NUM_CTRL, 0);
-  uint64_t smmu_base_arr[num_smmus], pgt_attr_el3;
+  uint64_t smmu_base_arr_size, smmu_base_arr_pages;
+  uint64_t *smmu_base_arr = NULL;
+  uint64_t pgt_attr_el3;
 
   if (!val_is_mec_supported())
   {
@@ -46,8 +49,33 @@ val_rme_mec_execute_tests(uint32_t num_pe)
       return ACS_STATUS_SKIP;
   }
 
+  if (num_smmus == 0)
+  {
+      val_print(ACS_PRINT_WARN, " No SMMU Controller Found, Skipping RME-MEC tests...", 0);
+      return ACS_STATUS_SKIP;
+  }
+
   if (!g_rl_smmu_init)
   {
+      page_size = val_memory_page_size();
+      if (page_size == 0)
+      {
+        val_print(ACS_PRINT_ERR, " Invalid page size for smmu_base_arr allocation", 0);
+        return ACS_STATUS_ERR;
+      }
+
+      smmu_base_arr_size = num_smmus * sizeof(*smmu_base_arr);
+      smmu_base_arr_pages = smmu_base_arr_size / page_size;
+      if ((smmu_base_arr_size % page_size) != 0)
+        smmu_base_arr_pages++;
+
+      smmu_base_arr = val_memory_alloc_pages((uint32_t)smmu_base_arr_pages);
+      if (smmu_base_arr == NULL)
+      {
+        val_print(ACS_PRINT_ERR, " Failed to allocate smmu_base_arr", 0);
+        return ACS_STATUS_ERR;
+      }
+
       smmu_cnt = 0;
 
       while (smmu_cnt < num_smmus)
@@ -58,18 +86,23 @@ val_rme_mec_execute_tests(uint32_t num_pe)
       /* Map the Pointer in EL3 as NS Access PAS so that EL3 can access this struct pointers */
       pgt_attr_el3 = LOWER_ATTRS(PGT_ENTRY_ACCESS | SHAREABLE_ATTR(OUTER_SHAREABLE) |
                                  PGT_ENTRY_AP_RW | PAS_ATTR(NONSECURE_PAS));
-      if (val_add_mmu_entry_el3((uint64_t)(smmu_base_arr), (uint64_t)(smmu_base_arr), pgt_attr_el3))
+      if (val_add_mmu_entry_el3((uint64_t)(smmu_base_arr),
+                                (uint64_t)val_memory_virt_to_phys(smmu_base_arr),
+                                pgt_attr_el3))
       {
         val_print(ACS_PRINT_ERR, " MMU mapping failed for smmu_base_arr", 0);
+        val_memory_free_pages(smmu_base_arr, (uint32_t)smmu_base_arr_pages);
         return ACS_STATUS_ERR;
       }
       if (val_rlm_smmu_init(num_smmus, smmu_base_arr))
       {
         val_print(ACS_PRINT_ERR, " SMMU REALM INIT failed", 0);
+        val_memory_free_pages(smmu_base_arr, (uint32_t)smmu_base_arr_pages);
         return ACS_STATUS_ERR;
       }
 
       g_rl_smmu_init = 1;
+      val_memory_free_pages(smmu_base_arr, (uint32_t)smmu_base_arr_pages);
   }
 
   reset_status = val_read_reset_status();


### PR DESCRIPTION
- Skip platform-resource tests when required SMEM, RNVS, MTE, GPC, or PAS-filter regions are not described by the platform.
- Skip SMMU/PCIe-dependent tests when SMMU, exerciser, ATS, or DA prerequisites are absent.
- Fail reset-based tests if the reset helper returns unexpectedly


Change-Id: I3c65af8c975158215e5a8eab947edd45632708a7